### PR TITLE
Remove debugging prints

### DIFF
--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -96,7 +96,6 @@ def tweak_wcs(refcat, imcat, imwcs, fitgeom='general', nclip=3, sigma=3.0):
 
     wimcat = WCSImageCatalog(imcat, imwcs, shape=None,
                              name=imcat.meta.get('name', None))
-    print(wimcat.catalog)
     wgcat = WCSGroupCatalog(wimcat, name=imcat.meta.get('name', None))
     wrefcat = RefCatalog(refcat, name=imcat.meta.get('name', None))
 

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -387,9 +387,6 @@ class WCSImageCatalog(object):
 
         x = self.catalog['x']
         y = self.catalog['y']
-        print("^^^ x: {}".format(x))
-        print("^^^ y: {}".format(y))
-        print("^^^ len(x): {}".format(len(x)))
 
         if len(x) == 0:
             # no points
@@ -431,7 +428,6 @@ class WCSImageCatalog(object):
         dec[-1] = dec[0]
 
         self._bb_radec = (ra, dec)
-        print("^^^ ra, dec = {}".format(self._bb_radec))
         self._polygon = SphericalPolygon.from_radec(ra, dec)
         self._poly_area = np.fabs(self._polygon.area())
 


### PR DESCRIPTION
This PR removes debugging prints left over from when I was trying to understand why the code did not work. It turns out it was a bug in `jwst_pipeline` already fixed.