### PR TITLE
Initialize JWSTgWCS using wcsinfo instead of individual ref angles

### DIFF
--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -251,7 +251,7 @@ class TPMatch(MatchCatalogs):
 
         tolerance = self._tolerance
 
-        ps = 1.0 if tp_wcs is None else tp_wcs.tanp_center_pixel_scale()
+        ps = 1.0 if tp_wcs is None else tp_wcs.tanp_center_pixel_scale
 
         if self._use2dhist:
             # Determine xyoff (X,Y offset) and tolerance


### PR DESCRIPTION
This PR makes it easier to initialize a JWST-specific WCS object using `meta.wcsinfo` instead of explicitly passing each angle to the initializer.

CC: @larrybradley @hcferguson 

If you are trying to run examples from PRs #1 or #2, then you will need to replace the following step:
```python
# create TPWCS object with the WCS that needs to be corrected:
wcsinfo = im1.meta.wcsinfo._instance
imwcs = JWSTgWCS(
    wcs=deepcopy(im1.meta.wcs),
    v2_ref=wcsinfo['v2_ref'] / 3600.0,
    v3_ref=wcsinfo['v3_ref'] / 3600.0,
    roll_ref=wcsinfo['roll_ref'],
    ra_ref=wcsinfo['ra_ref'],
    dec_ref=wcsinfo['dec_ref']
)
```
with the following simple statement:
```python
# create TPWCS object with the WCS that needs to be corrected:
imwcs = JWSTgWCS(wcs=deepcopy(im1.meta.wcs), im1.meta.wcsinfo._instance)
```