### PR TITLE
Add a function that tweaks multiple nddata images at once

### DIFF
--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -851,7 +851,7 @@ class WCSGroupCatalog(object):
             # alignment to the tangent plane of another image in the group:
             if imcat.imwcs == tanplane_wcs:
                 m = matrix.copy()
-                s = s.copy()
+                s = shift.copy()
             else:
                 r1, t1 = _tp2tp(imcat.imwcs, tanplane_wcs)
                 r2, t2 = _tp2tp(tanplane_wcs, imcat.imwcs)
@@ -932,7 +932,7 @@ class WCSGroupCatalog(object):
         self.calc_tanp_xy(tanplane_wcs=tanplane_wcs)
         refcat.calc_tanp_xy(tanplane_wcs=tanplane_wcs)
 
-        nmatches, _, _ = self.match2ref(refcat=refcat, match=match)
+        nmatches, _, _ = self.match2ref(refcat=refcat.catalog, match=match)
         if nmatches < minobj:
             name = 'Unnamed' if self.name is None else self.name
             log.warning("Not enough matches (< {:d}) found for image "


### PR DESCRIPTION
This PR adds another function, `tweak_image_wcs()` that not only allows adjusting the WCS of multiple images at once (equivalent to calling `tweak_wcs()` in a loop for each input catalog) but also incorporates several operations on input image objects (such as calling `match()`, updating image object's `wcs`, etc.).

The most important difference, however, is that due to the fact that this function takes multiple images (as opposite to two catalogs accepted by `tweak_wcs()`), this function can optimize the order in which image alignment should occur and also expand the reference catalog with new sources from already aligned images. This allows alignment of images that do not all overlap but overlap only in pairs.

CC: @larrybradley @hcferguson 