### PR TITLE
Add SCA auto-grouping for JWST data

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Content
    tweakwcs/tpwcs
    tweakwcs/matchutils
    tweakwcs/linearfit
+   tweakwcs/groupwcs
    LICENSE.rst
 
 

--- a/docs/tweakwcs/groupwcs.rst
+++ b/docs/tweakwcs/groupwcs.rst
@@ -1,0 +1,11 @@
+========
+groupwcs
+========
+
+.. moduleauthor:: Mihai Cara <help@stsci.edu>
+
+.. currentmodule:: tweakwcs.groupwcs
+
+.. automodule:: tweakwcs.groupwcs
+   :members:
+   :undoc-members:

--- a/tweakwcs/groupwcs.py
+++ b/tweakwcs/groupwcs.py
@@ -1,0 +1,112 @@
+"""
+A module that provides functions for automatically adding ``tweakwcs_group_id``
+tag to images based on information recorded in image's ``meta`` attribute.
+
+This ``tweakwcs_group_id`` tag, if set, can be used by ``tweak_wcs``,
+``tweak_image_wcs``, and other functions from the ``imalign`` module to
+identify images that should be treated together as a group when "tweaking"
+their ``WCS``. That is, all images within a group will have the same
+correction applied to their ``WCS``\ es. This is often the case with images
+that come from differenct chips of the same sensor chip assembly (SCA).
+
+.. note::
+    Grouping logic/algorithms are inherently telescope and instrument
+    dependent.
+
+:Authors: Mihai Cara (contact: help@stsci.edu)
+
+:License: :doc:`../LICENSE`
+
+"""
+# STDLIB
+import logging
+import uuid
+from datetime import datetime
+import collections
+from copy import deepcopy
+
+# THIRD PARTY
+import numpy as np
+import astropy
+from astropy.nddata import NDDataBase
+from jwst.datamodels import open as open_jwst_data
+import jwst
+
+# LOCAL
+
+
+from . import __version__, __version_date__
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+import sys
+log.addHandler(logging.StreamHandler(stream=sys.stdout))
+
+
+def assign_jwst_tweakwcs_groups(images):
+    """ Assign group IDs to ``JWST`` images.
+
+    Parameters
+    ----------
+    images : list of str or jwst.datamodels.DataModel
+        A list of string file names to ``JWST`` data or
+        `jwst.datamodels.DataModel` objects. On treturn, these data models
+        or files will contain ``tweakwcs_group_id`` attribute in their
+        ``meta`` dictionary identifying the tweakwcs group. Images within
+        a group are aligned together.
+
+    """
+    close = [isinstance(im, (str, bytes)) for im in images]
+
+    group_ids = {}
+
+    for im, cl in zip(images, close):
+        model = open_jwst_data(im) if cl else im
+        try:
+            meta_ids = (
+                model.meta.observation.program_number,
+                model.meta.observation.observation_number,
+                model.meta.observation.visit_number,
+                model.meta.observation.visit_group,
+                model.meta.observation.sequence_id,
+                model.meta.observation.activity_id,
+                model.meta.observation.exposure_number
+            )
+
+            if meta_ids in group_ids:
+                gid = group_ids[meta_ids]
+            else:
+                gid = str(uuid.uuid4())
+                while gid in group_ids.values():
+                    gid = str(uuid.uuid4())
+                group_ids[meta_ids] = gid
+
+        except:
+            gid = 'None'
+            log.warning("Unable to assign a 'tweakwcs_group_id' to image "
+                        "'{}'".format(model.meta['filename']))
+            log.warning("'tweakwcs_group_id' for image '{}' will be set "
+                        "to None".format(model.meta['filename']))
+
+        finally:
+            if "tweakwcs_group_id" not in model.meta:
+                twgid_schema = {
+                    "type": "object",
+                    "properties": {
+                        "meta": {
+                            "type": "object",
+                            "properties": {
+                                "tweakwcs_group_id": {
+                                    "title": "tweakwcs group ID",
+                                    "type": "string",
+                                    "fits_keyword": "TWEAKGID"
+                                }
+                            }
+                        }
+                    }
+                }
+                model.extend_schema(twgid_schema)
+            model.meta.tweakwcs_group_id = gid
+
+            if cl:
+                model.save(model.meta.filename)


### PR DESCRIPTION
This adds SCA auto-grouping utility function for `JWST` data.

CC: @larrybradley @hcferguson 