### PR TITLE
Fix a type in branching by number of points

### DIFF
--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -1135,7 +1135,7 @@ class RefCatalog(object):
             xv = [x[0] - 0.5, x[0] - 0.5, x[0] + 0.5, x[0] + 0.5, x[0] - 0.5]
             yv = [y[0] - 0.5, y[0] + 0.5, y[0] + 0.5, y[0] - 0.5, y[0] - 0.5]
 
-        elif len(xv) == 3:
+        elif len(xv) == 2:
             # two points. build a small box around them:
             x, y = convex_hull(x, y, wcs=None)
 


### PR DESCRIPTION
This is an obvious typo that needs to be fixed and affects computation of a the convex hull when only 2 or 3 sources are present.