### PR TITLE
Add customizable FITS WCS alignment to reference catalogs

### DIFF
--- a/notebooks/align_fits_wcs.ipynb
+++ b/notebooks/align_fits_wcs.ipynb
@@ -14,7 +14,8 @@
     "***\n",
     "## About this Notebook\n",
     "**Author:** Mihai Cara, STScI\n",
-    "<br>**Initial Version On:** 11/20/2018"
+    "<br>**Initial version on:** 11/20/2018\n",
+    "<br>**Updated on:** 11/28/2018"
    ]
   },
   {
@@ -49,16 +50,14 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from astropy.io import fits\n",
-    "\n",
-    "from stwcs.wcsutil import HSTWCS\n",
+    "from astropy.nddata import NDData\n",
     "from astroquery.mast import Observations\n",
-    "from drizzlepac import updatehdr\n",
-    "\n",
-    "from tweakwcs import tweak_wcs, tweak_image_wcs, FITSWCS\n",
     "from photutils import detect_threshold, DAOStarFinder\n",
     "\n",
-    "import os\n",
-    "os.chdir('/Users/mcara/repo/tweakwcs/notebooks/')"
+    "from stwcs.wcsutil import HSTWCS\n",
+    "from drizzlepac import updatehdr\n",
+    "\n",
+    "from tweakwcs import tweak_wcs, tweak_image_wcs, FITSWCS, TPMatch"
    ]
   },
   {
@@ -79,6 +78,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# If mastDownload directory already exists, delete it\n",
+    "# and all subdirectories it contains:\n",
+    "if os.path.isdir('mastDownload'):\n",
+    "    shutil.rmtree('mastDownload')\n",
+    "\n",
     "# Retrieve the observation information.\n",
     "obs_table = Observations.query_criteria(obs_id='j8bt06*', filters='F606W', obstype='ALL')\n",
     "products = Observations.get_product_list(obs_table)\n",
@@ -88,20 +92,25 @@
     "                               productSubGroupDescription=['FLC', 'FLT'], \n",
     "                               extension='fits')\n",
     "\n",
-    "# Move the files from the mastDownload directory to the current working\n",
-    "# directory and make a backup of the files.\n",
-    "downloaded_fits_files = glob.glob('mastDownload/HST/j*/j*flt.fits')\n",
-    "fits_files = []\n",
-    "for fil in downloaded_fits_files:\n",
-    "    base_name = os.path.basename(fil)\n",
-    "    fits_files.append(base_name)\n",
-    "    if os.path.isfile(base_name):\n",
-    "        os.remove(base_name)\n",
-    "    shutil.move(fil, '.')\n",
+    "def copy_mast_to_cwd():\n",
+    "    \"\"\"\n",
+    "    Move the files from the mastDownload directory to the current working\n",
+    "    directory and make a backup of the files. Return a list of image file\n",
+    "    names in the CWD.\n",
     "    \n",
-    "# Delete the mastDownload directory and all subdirectories it contains.\n",
-    "if os.path.isdir('mastDownload'):\n",
-    "    shutil.rmtree('mastDownload')"
+    "    \"\"\"\n",
+    "    downloaded_fits_files = glob.glob('mastDownload/HST/j*/j*flt.fits')\n",
+    "    fits_files = []\n",
+    "    for fil in downloaded_fits_files:\n",
+    "        base_name = os.path.basename(fil)\n",
+    "        fits_files.append(base_name)\n",
+    "        if os.path.isfile(base_name):\n",
+    "            os.remove(base_name)\n",
+    "        shutil.copy2(fil, '.')\n",
+    "        \n",
+    "    return fits_files\n",
+    "\n",
+    "fits_files = copy_mast_to_cwd()"
    ]
   },
   {
@@ -127,8 +136,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.nddata import NDData\n",
-    "\n",
     "images = []\n",
     "for group_id, file in enumerate(fits_files):\n",
     "    with fits.open(file) as hdulist:\n",
@@ -143,7 +150,7 @@
     "        # the same group ID to the images corresponding to different\n",
     "        # SCI extensions *of the same FITS file* so that they can be\n",
     "        # aligned together.\n",
-    "        img = NDData(data=im_data, mask=dq_data != 0, wcs=w, meta={'group_id': group_id})\n",
+    "        img = NDData(data=im_data, mask=dq_data != 0, wcs=w, meta={'group_id': group_id + 1})\n",
     "        images.append(img)"
    ]
   },
@@ -208,11 +215,152 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## EXAMPLE 2: Customizable Workflow to Align Two or More Images or to Align to an External Reference Catalog\n",
+    "\n",
+    "In this example we show how to use lower-level functions to align two images. This approach allows significantly higher customization compared to the use of the convenience function `tweak_image_wcs()` from Example 1. In addition, this approach allows inspection and logging of intermediate results such as number of matched sources, their indices in the corresponding catalogs, linear fit results, fit residuals, etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Get a Fresh Copy of Data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "fits_files = copy_mast_to_cwd()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Create Catalogs and Create a Telescope/Instrument-specific \"corrector\" WCS object\n",
+    "\n",
+    "Below we take the sources from the first image to create a \"reference\" catalog. Therefore this example can be used also for aligning images to _external_ \"reference\" catalogs. Since we are working with HST images that use FITS WCS, we will use `FITSWCS` tangent plane corrector specific to FITS WCS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalogs = []\n",
+    "\n",
+    "for group_id, file in enumerate(fits_files):\n",
+    "    with fits.open(file) as hdulist:\n",
+    "        im_data = hdulist[('SCI', 1)].data\n",
+    "        dq_data = hdulist[('DQ', 1)].data\n",
+    "        w = HSTWCS(hdulist, ('SCI', 1))\n",
+    "        \n",
+    "        # create FITS WCS corrector object\n",
+    "        wcs_corrector = FITSWCS(w)\n",
+    "        \n",
+    "        # find stars:\n",
+    "        threshold = detect_threshold(im_data, snr=100.0)[0, 0]\n",
+    "        daofind = DAOStarFinder(fwhm=2.5, threshold=threshold, exclude_border=True)\n",
+    "        cat = daofind(im_data)\n",
+    "        cat.rename_column('xcentroid', 'x')\n",
+    "        cat.rename_column('ycentroid', 'y')\n",
+    "        cat.meta['name'] = 'im{:d} sources'.format(group_id + 1)\n",
+    "        cat.meta['file_name'] = file\n",
+    "        print(\"Length of catalog #{:d}: {:d}\".format(catno + 1, len(cat)))\n",
+    "        \n",
+    "        catalogs.append((cat, wcs_corrector))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a \"reference\" catalog based on the first image's stars. A reference catalog must have star coordinates in world coordinates. When using external reference catalog, this step essentially can be skipped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "refcat, refwcs = catalogs.pop(0)\n",
+    "refcat.meta['name'] = 'REFCAT ({})'.format(refcat.meta['name'])\n",
+    "\n",
+    "# convert image coordinates to sky coords:\n",
+    "ra, dec = refwcs.det_to_world(refcat['x'], refcat['y'])\n",
+    "refcat['RA'] = ra\n",
+    "refcat['DEC'] = dec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Match Catalogs and Align Image WCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match = TPMatch(searchrad=5, separation=0.1, tolerance=5, use2dhist=False)\n",
+    "\n",
+    "for imcat, imwcs in catalogs:\n",
+    "    # Match sources in the catalogs:\n",
+    "    ridx, iidx = match(refcat, imcat, imwcs)\n",
+    "    \n",
+    "    # Align image WCS:\n",
+    "    aligned_imwcs = tweak_wcs(refcat[ridx], imcat[iidx], imwcs).wcs\n",
+    "    imcat.meta['aligned_wcs'] = aligned_imwcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4 Update FITS File Headers with Aligned WCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for cat, _ in catalogs:\n",
+    "    with fits.open(cat.meta['file_name'], mode='update') as hdulist:\n",
+    "        updatehdr.update_wcs(hdulist, 1, cat.meta['aligned_wcs'], wcsname='TWEAK', reusename=True, verbose=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## Delete Downloaded Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the mastDownload directory and all subdirectories it contains:\n",
+    "if os.path.isdir('mastDownload'):\n",
+    "    shutil.rmtree('mastDownload')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Add a second example of aligning FITS WCS using lower-level functions. The same workflow can be used for aligning images to an external reference catalog.

CC: @stsci-hack 