### PR TITLE
Return fit and match info in TPWCS and NDData meta

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Content
    tweakwcs/imalign
    tweakwcs/tpwcs
    tweakwcs/matchutils
+   tweakwcs/wcsimage
    tweakwcs/linearfit
    tweakwcs/groupwcs
    LICENSE.rst

--- a/docs/tweakwcs/wcsimage.rst
+++ b/docs/tweakwcs/wcsimage.rst
@@ -1,0 +1,11 @@
+========
+wcsimage
+========
+
+.. moduleauthor:: Mihai Cara <help@stsci.edu>
+
+.. currentmodule:: tweakwcs.wcsimage
+
+.. automodule:: tweakwcs.wcsimage
+   :members:
+   :undoc-members:


### PR DESCRIPTION
`tweak_image_wcs` now will add `'tweakwcs_info'` key to the meta attribute of input `NDData` objects which will point to a dictionary of various fit and match info.

`tweak_wcs` will directly set these fit info on `TPWCS.meta`.

For example,

```python
tweak_image_wcs([im1, im2])
twinfo1 = im1.meta.info('tweakwcs_info', None)
if twinfo1 is None:
    print("image 1 was used as a reference image and was not aligned")
else:
    print(twinfo1)  # for standard NDData
    # print(twinfo1.instance)  # for JWST ImageModel.meta
```

CC: @stsci-hack @shannnnnyyy 