### PR TITLE
Fix undefined variable when refcat is provided

### DIFF
--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -309,9 +309,9 @@ def tweak_image_wcs(images, refcat=None, enforce_user_order=True,
                                "and 'DEC' columns.")
 
         else:
-            raise TypeError("Unsupported 'refcat' type. Supported types: "
-                            "astropy.nddata.NDDataBase and "
-                            "astropy.table.Table")
+            raise TypeError("Unsupported 'refcat' type. Supported 'refcat' "
+                            "types are 'astropy.nddata.NDDataBase' and "
+                            "'astropy.table.Table'")
 
         refcat = RefCatalog(refcat, name=refcat.meta.get('name', None))
 

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -282,7 +282,7 @@ def tweak_image_wcs(images, refcat=None, enforce_user_order=True,
 
             rcat = refcat.meta['catalog'].copy()
 
-            if 'RA' not in catalog.colnames or 'DEC' not in catalog.colnames:
+            if 'RA' not in rcat.colnames or 'DEC' not in rcat.colnames:
                 # convert image x & y to world coordinates:
                 if not 'wcs' in refcat:
                     raise ValueError("A valid WCS is required to convert "
@@ -304,9 +304,14 @@ def tweak_image_wcs(images, refcat=None, enforce_user_order=True,
             refcat = rcat
 
         elif isinstance(refcat,  astropy.table.Table):
-            if 'RA' not in catalog.colnames or 'DEC' not in catalog.colnames:
+            if 'RA' not in refcat.colnames or 'DEC' not in refcat.colnames:
                 raise KeyError("Reference catalogs *must* contain *both* 'RA' "
                                "and 'DEC' columns.")
+
+        else:
+            raise TypeError("Unsupported 'refcat' type. Supported types: "
+                            "astropy.nddata.NDDataBase and "
+                            "astropy.table.Table")
 
         refcat = RefCatalog(refcat, name=refcat.meta.get('name', None))
 

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -43,8 +43,8 @@ class TPWCS(ABC):
         Parameters
         ----------
 
-        wcs : GWCS
-            A `GWCS` object.
+        wcs : ``WCS object``
+            A `WCS` object supported by a child class.
 
         """
         self._owcs = wcs
@@ -69,7 +69,7 @@ class TPWCS(ABC):
     def set_correction(self, matrix=[[1, 0], [0, 1]], shift=[0, 0], meta=None,
                        **kwargs):
         """
-        Sets a tangent-plane correction of the GWCS object according to
+        Sets a tangent-plane correction of the WCS object according to
         the provided liniar parameters. In addition, this function updates
         the ``meta`` attribute of the `TPWCS`-derived object with the values
         of keyword arguments except for the argument ``meta`` which is


### PR DESCRIPTION
This PR addresses the issue described in https://github.com/spacetelescope/tweakwcs/pull/22 and adds safeguards to detect when a reference catalog has an unsupported type. (and a small doc fix).

The fix in this PR will work when reference catalog is of `astropy.nddata.NDData` type unlike the fix proposed in https://github.com/spacetelescope/tweakwcs/pull/22.

CC: @stsci-hack 