### PR TITLE
Add alignment status to tweakwcs_info meta

### DIFF
--- a/tweakwcs/linearfit.py
+++ b/tweakwcs/linearfit.py
@@ -70,6 +70,8 @@ def iter_linear_fit(xy, uv, xyindx=None, uvindx=None, xyorig=None, uvorig=None,
     if nclip is None:
         nclip = 0
 
+    effective_nclip = 0
+
     # define index to initially include all points
     for n in range(nclip):
         resids = fit['resids']
@@ -84,6 +86,8 @@ def iter_linear_fit(xy, uv, xyindx=None, uvindx=None, xyorig=None, uvorig=None,
 
         if ngoodpix < minobj:
             break
+
+        effective_nclip += 1
 
         npts0 = npts - goodpix.shape[0]
         xy = xy[goodpix]
@@ -107,6 +111,7 @@ def iter_linear_fit(xy, uv, xyindx=None, uvindx=None, xyorig=None, uvorig=None,
     fit['ref_indx'] = uvindx
     fit['img_orig_xy'] = xyorig
     fit['ref_orig_xy'] = uvorig
+    fit['eff_nclip'] = effective_nclip
 
     return fit
 


### PR DESCRIPTION
This PR adds a new `'status'` keyword that is being added to the `tweakwcs_info` value in images' meta attribute. This allows to check the status of alignment: 'SUCCESS', 'REFERENCE' (to indicate that an image was not aligned because it was *chosen* to be a reference image), or 'FAILED'.

Other improvements:

* Added `'eff_nclip'` to the `fit` results dictionary. May be added later to the `tweakwcs_info` in image's meta at a later time if this kind of detail is necessary.

* Improved documentation

* More robust detection of JWST `DataModel` and correct extraction of the `gWCS` WCS from it.

* Now `image.meta['tweakwcs_info']` is always present in images' `meta` upon return from `tweak_image_wcs()`. No need to check for its presence.