### PR TITLE
Update reported indices in `fit` after clipping iterations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Release Notes
 tweakwcs (DEVELOPMENT)
 ======================
 
+- Fixeded a bug due to which ``'fit_ref_idx'`` and ``'fit_input_idx'``
+  fields in the ``fit`` dictionary were never updated. [#31]
+
 - ``jwst`` (pipeline) package is no longer a hard dependency. [#30]
 
 - Removed unnecessary install dependencies. [#30]


### PR DESCRIPTION
This PR fixes the code to update ``'fit_ref_idx'`` and ``'fit_input_idx'`` fields in the reported fit results. These fields are the indices of the matched sources after some of them are clipped away during the _fitting_ process (_after matching_). Therefore the length of these indices is (usually) smaller than that of the _matched_ indices.

**NOTE:** Due to the bug in `xyxymatch` described in https://github.com/spacetelescope/stsci.stimage/issues/8, matched indices (and possibly "fit" indices) may contain duplicates.