### PR TITLE
Use Gauss-Jordan method for inverting matrices with longdouble

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Content
    linearfit
    groupwcs
    wcsutils
+   linalg
    LICENSE.rst
 
 

--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -1,0 +1,11 @@
+======
+linalg
+======
+
+.. moduleauthor:: Mihai Cara <help@stsci.edu>
+
+.. currentmodule:: tweakwcs.linalg
+
+.. automodule:: tweakwcs.linalg
+   :members:
+   :undoc-members:

--- a/tweakwcs/__init__.py
+++ b/tweakwcs/__init__.py
@@ -12,5 +12,7 @@ from .tpwcs import *
 from .matchutils import *
 from .imalign import *
 from .wcsimage import *
+from .linalg import *
+from .linearfit import *
 #from .jwst_types import *
 #from .jwextension import *

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -1,0 +1,159 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module provides general purpose and/or specialized linear algebra
+routines.
+
+:Authors: Mihai Cara (contact: help@stsci.edu)
+
+:License: :doc:`../LICENSE`
+
+"""
+# STDLIB
+import logging
+
+# THIRD-PARTY
+import numpy as np
+
+# LOCAL
+from . import __version__, __version_date__
+
+__author__ = 'Mihai Cara'
+
+__all__ = ['inv']
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+def _is_longdouble_lte_flt64():
+    if np.longdouble is np.float64:
+        return True
+
+    fi1 = np.finfo(np.longdouble)
+    fi2 = np.finfo(np.float64)
+
+    lte_flt = all(
+        [
+            fi1.eps >= fi2.eps,
+            fi1.bits <= fi2.bits,
+            fi1.epsneg >= fi2.epsneg,
+            fi1.iexp <= fi2.iexp,
+            fi1.max <= fi2.max,
+            fi1.maxexp <= fi2.maxexp,
+            fi1.min >= fi2.min,
+            fi1.minexp >= fi2.minexp,
+            fi1.negep >= fi2.negep,
+            fi1.nexp <= fi1.nexp,
+            fi1.nmant <= fi2.nmant,
+            fi1.precision <= fi2.precision,
+            fi1.resolution >= fi2.resolution,
+            fi1.tiny >= fi2.tiny,
+        ]
+    )
+
+    return lte_flt
+
+
+_USE_NUMPY_LINALG_INV = _is_longdouble_lte_flt64()
+
+
+def inv(m):
+    """ This function computes inverse matrix using Gauss-Jordan elimination
+    with full pivoting. Computations are performed using ``numpy.longdouble``
+    precision. On systems on which ``numpy.longdouble`` is equivalent to
+    ``numpy.float64`` this function reverts to `numpy.linalg.inv` for
+    performance reasons.
+
+    Parameters
+    ----------
+    m : numpy.ndarray
+        A 2D *square* matrix of type `numpy.ndarray`.
+
+    Returns
+    -------
+    invm : numpy.ndarray
+        Inverse matrix of the input matrix ``m``: a 2D *square* `numpy.ndarray`
+        of type ``numpy.longdouble`` on systems on which it is more accurate
+        than ``numpy.float64``.
+
+    """
+    # check that matrix is square:
+    if _USE_NUMPY_LINALG_INV:
+        return np.linalg.inv(m)
+
+    m = np.array(m, dtype=np.longdouble)
+    if len(m.shape) != 2 or m.shape[0] != m.shape[1]:
+        raise ValueError("Input matrix must be a square matrix.")
+    order = m.shape[0]
+
+    # create permutation matrices:
+    qt = np.eye(order, dtype=np.int)
+
+    eps = np.finfo(np.float64).tiny
+
+    # initial inverse matrix:
+    invm = np.eye(order, dtype=np.longdouble)
+
+    # forward Gauss elimination with full pivoting:
+    for k in range(order):
+        # find pivot:
+        im, jm = np.unravel_index(np.argmax(np.abs(m[k:, k:])),
+                                  (order - k, order - k))
+        im += k
+        jm += k
+
+        pv = m[im, jm]
+
+        # detect singularity:
+        if np.abs(pv) < eps:
+            raise ArithmeticError('Singular matrix.')
+
+        if im != k or jm != k:
+            # swap rows & columns:
+            p = np.eye(order, dtype=np.int)
+            q = np.eye(order, dtype=np.int)
+
+            # swap rows in the m and invm matrix:
+            tmp_row = np.array(m[k, :])
+            m[k, :] = m[im, :]
+            m[im, :] = tmp_row
+
+            tmp_row = np.array(invm[k, :])
+            invm[k, :] = invm[im, :]
+            invm[im, :] = tmp_row
+
+            # swap rows in the Q matrix:
+            tmp_row = np.array(q[k, :])
+            q[k, :] = q[jm, :]
+            q[jm, :] = tmp_row
+
+            # swap columns:
+            m = np.dot(m, q)
+            invm = np.dot(invm, q)
+            qt = np.dot(qt, q)
+
+        m[k, k:] /= pv
+        r = m[k, (k + 1):]
+
+        invm[k, :] /= pv
+        w = invm[k, :]
+
+        for l in range(k + 1, order):
+            pv2 = m[l, k]
+            m[l, (k + 1):] -= pv2 * r
+            m[l, k] = 0.0
+            invm[l, :] -= pv2 * w
+
+    # inverse Jordan elimination:
+    for k1 in range(order - 1, 0, -1):
+        for k2 in range(k1 - 1, -1, -1):
+            invm[k2, :] -= m[k2, k1] * invm[k1, :]
+
+    # detect singularity:
+    if not np.all(np.isfinite(invm)):
+        raise ArithmeticError('Singular matrix.')
+
+    # undo permutations:
+    invm = np.dot(qt, np.dot(invm, qt.T))
+
+    return invm

--- a/tweakwcs/linearfit.py
+++ b/tweakwcs/linearfit.py
@@ -11,6 +11,7 @@ sets of 2D points.
 import logging
 import numpy as np
 
+from .linalg import inv
 from . import __version__, __version_date__
 
 __author__ = 'Mihai Cara, Warren Hack'
@@ -352,22 +353,6 @@ def fit_rscale(xy, uv, wxy=None, wuv=None):
     return fit
 
 
-def _inv3x3(x):
-    """ Return inverse of a 3-by-3 matrix.
-    """
-    x0 = x[:, 0]
-    x1 = x[:, 1]
-    x2 = x[:, 2]
-    m = np.array([np.cross(x1, x2), np.cross(x2, x0), np.cross(x0, x1)])
-    d = np.dot(x0, np.cross(x1, x2))
-
-    if np.abs(d) < np.finfo(np.float64).tiny:
-        raise SingularMatrixError(
-            "Singular matrix: suspected colinear points."
-        )
-    return (m / d)
-
-
 def fit_general(xy, uv, wxy=None, wuv=None):
     """ Performs a simple fit for the shift only between
         matched lists of positions 'xy' and 'uv'.
@@ -457,13 +442,13 @@ def fit_general(xy, uv, wxy=None, wuv=None):
     U = np.array([Sx, Sxu, Sxv])
     V = np.array([Sy, Syu, Syv])
 
-    # The fit solutioN...
-    # where
-    #   u = P0 + P1*x + P2*y
-    #   v = Q0 + Q1*x + Q2*y
-    #
-    #invM = _inv3x3(M)
-    invM = np.linalg.inv(M.astype(np.float64))
+    try:
+        invM = inv(M)
+    except ArithmeticError:
+        raise SingularMatrixError(
+            "Singular matrix: suspected colinear points."
+        )
+
     P = np.dot(invM, U).astype(np.float64)
     Q = np.dot(invM, V).astype(np.float64)
     if not (np.all(np.isfinite(P)) and np.all(np.isfinite(Q))):


### PR DESCRIPTION
Current matrix inversion method suffers from rounding errors and it is less accurate than `numpy.linalg.inv` even though it uses `np.longdouble` for intermediate computations. This PR replaces the simplistic method used previously with Gauss-Jordan method with full pivoting. In simulations, this method is 3-4 digits more accurate than `np.linalg.inv()` on systems on which `np.longdouble` is not equivalent to `np.float64`.