### PR TITLE
Fix setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=38.2.5",
+    "wheel",
+    "numpy",
+]


### PR DESCRIPTION
Latest `setuptools` produces the following error during build:
```        
from setuptools import setup, find_packages, Extension, _install_setup_requires
ImportError: cannot import name '_install_setup_requires'
```

This implements `pyproject.toml` (PEP517) as a replacement.