### PR TITLE
[WIP] Fix void unknown size

### DIFF
--- a/src/carrutils.c
+++ b/src/carrutils.c
@@ -35,7 +35,8 @@ double **ptrvector(long n)
     Memory is allocated!                                    */
 double **pymatrix_to_Carrayptrs(PyArrayObject *arrayin)  {
     double **c, *a;
-    long i, n, m;
+    long i;
+    npy_int n, m;
 
     n = PyArray_DIMS(arrayin)[0];
     m = PyArray_DIMS(arrayin)[1];
@@ -92,10 +93,29 @@ arrxyzero(PyObject *obj, PyObject *args)
   imgnum = PyArray_DIMS(imgxy)[0];
   refnum = PyArray_DIMS(refxy)[0];
 
+  double dx_check, dy_check;
+  double c1, c2, c3, c4,
+         c5, c6, c7, c8,
+         c9, c10;
+
   /* For each entry in the input image...*/
   for (j=0; j< imgnum; j++){
     /* compute the delta relative to each source in ref image */
     for (k = 0; k < refnum; k++){
+        c1 = *(float *)PyArray_DATA(imgxy);
+        c2 = j * PyArray_STRIDES(imgxy)[0];
+        c3 = *(float *)PyArray_DATA(refxy);
+        c4 = k * PyArray_STRIDES(refxy)[0];
+        dx_check = (c1 + c2) - (c3 + c4);
+
+        c5 = *(float *)PyArray_DATA(imgxy);
+        c6 = j * PyArray_STRIDES(imgxy)[0];
+        c7 = PyArray_STRIDES(imgxy)[1];
+        c8 = *(float *)PyArray_DATA(refxy);
+        c9 = k * PyArray_STRIDES(refxy)[0];
+        c10 = PyArray_STRIDES(refxy)[1];
+        dy_check = (c5 + c6 + c7) - (c8 + c9 + c10);
+
         dx = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]) - *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]);
         dy = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]+ PyArray_STRIDES(imgxy)[1]) -
              *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]+ PyArray_STRIDES(refxy)[1]);

--- a/src/carrutils.c
+++ b/src/carrutils.c
@@ -35,11 +35,10 @@ double **ptrvector(long n)
     Memory is allocated!                                    */
 double **pymatrix_to_Carrayptrs(PyArrayObject *arrayin)  {
     double **c, *a;
-    long i;
-    npy_int n, m;
+    long i, n, m;
 
-    n = PyArray_DIMS(arrayin)[0];
-    m = PyArray_DIMS(arrayin)[1];
+    n = (long)PyArray_DIMS(arrayin)[0];
+    m = (long)PyArray_DIMS(arrayin)[1];
     c = (double **) ptrvector(n);
     a = (double *) PyArray_DATA(arrayin);  /* pointer to arrayin data as double */
     for (i=0; i<n; i++)
@@ -64,6 +63,9 @@ arrxyzero(PyObject *obj, PyObject *args)
   integer_t dimensions[2];
   integer_t xind, yind;
   double dx, dy;
+  double c1, c2, c3, c4,
+         c5, c6, c7, c8,
+         c9, c10;
   long j, k;
 
   if (!PyArg_ParseTuple(args,"OOd:arrxyzero", &oimgxy, &orefxy, &searchrad)){
@@ -90,35 +92,30 @@ arrxyzero(PyObject *obj, PyObject *args)
   /* Allocate memory for return matrix */
   zpmat = pymatrix_to_Carrayptrs(ozpmat);
 
-  imgnum = PyArray_DIMS(imgxy)[0];
-  refnum = PyArray_DIMS(refxy)[0];
-
-  double dx_check, dy_check;
-  double c1, c2, c3, c4,
-         c5, c6, c7, c8,
-         c9, c10;
+  imgnum = (long)PyArray_DIMS(imgxy)[0];
+  refnum = (long)PyArray_DIMS(refxy)[0];
 
   /* For each entry in the input image...*/
   for (j=0; j< imgnum; j++){
     /* compute the delta relative to each source in ref image */
     for (k = 0; k < refnum; k++){
         c1 = *(float *)PyArray_DATA(imgxy);
-        c2 = j * PyArray_STRIDES(imgxy)[0];
+        c2 = j * (long)PyArray_STRIDES(imgxy)[0];
         c3 = *(float *)PyArray_DATA(refxy);
-        c4 = k * PyArray_STRIDES(refxy)[0];
-        dx_check = (c1 + c2) - (c3 + c4);
+        c4 = k * (long)PyArray_STRIDES(refxy)[0];
+        dx = (c1 + c2) - (c3 + c4);
 
         c5 = *(float *)PyArray_DATA(imgxy);
-        c6 = j * PyArray_STRIDES(imgxy)[0];
-        c7 = PyArray_STRIDES(imgxy)[1];
+        c6 = j * (long)PyArray_STRIDES(imgxy)[0];
+        c7 = (long)PyArray_STRIDES(imgxy)[1];
         c8 = *(float *)PyArray_DATA(refxy);
-        c9 = k * PyArray_STRIDES(refxy)[0];
-        c10 = PyArray_STRIDES(refxy)[1];
-        dy_check = (c5 + c6 + c7) - (c8 + c9 + c10);
+        c9 = k * (long)PyArray_STRIDES(refxy)[0];
+        c10 = (long)PyArray_STRIDES(refxy)[1];
+        dy = (c5 + c6 + c7) - (c8 + c9 + c10);
 
-        dx = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]) - *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]);
-        dy = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]+ PyArray_STRIDES(imgxy)[1]) -
-             *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]+ PyArray_STRIDES(refxy)[1]);
+        //dx = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]) - *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]);
+        //dy = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]+ PyArray_STRIDES(imgxy)[1]) -
+        //     *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]+ PyArray_STRIDES(refxy)[1]);
         if ((fabs(dx) < searchrad) && (fabs(dy) < searchrad)) {
             xind = (integer_t)(dx+searchrad);
             yind = (integer_t)(dy+searchrad);

--- a/src/carrutils.c
+++ b/src/carrutils.c
@@ -63,9 +63,6 @@ arrxyzero(PyObject *obj, PyObject *args)
   integer_t dimensions[2];
   integer_t xind, yind;
   double dx, dy;
-  double c1, c2, c3, c4,
-         c5, c6, c7, c8,
-         c9, c10;
   long j, k;
 
   if (!PyArg_ParseTuple(args,"OOd:arrxyzero", &oimgxy, &orefxy, &searchrad)){
@@ -99,23 +96,12 @@ arrxyzero(PyObject *obj, PyObject *args)
   for (j=0; j< imgnum; j++){
     /* compute the delta relative to each source in ref image */
     for (k = 0; k < refnum; k++){
-        c1 = *(float *)PyArray_DATA(imgxy);
-        c2 = j * (long)PyArray_STRIDES(imgxy)[0];
-        c3 = *(float *)PyArray_DATA(refxy);
-        c4 = k * (long)PyArray_STRIDES(refxy)[0];
-        dx = (c1 + c2) - (c3 + c4);
+        dx = (*(float *)PyArray_DATA(imgxy) + j * (long)PyArray_STRIDES(imgxy)[0])
+           - (*(float *)PyArray_DATA(refxy) + k * (long)PyArray_STRIDES(refxy)[0]);
 
-        c5 = *(float *)PyArray_DATA(imgxy);
-        c6 = j * (long)PyArray_STRIDES(imgxy)[0];
-        c7 = (long)PyArray_STRIDES(imgxy)[1];
-        c8 = *(float *)PyArray_DATA(refxy);
-        c9 = k * (long)PyArray_STRIDES(refxy)[0];
-        c10 = (long)PyArray_STRIDES(refxy)[1];
-        dy = (c5 + c6 + c7) - (c8 + c9 + c10);
+        dy = (*(float *)PyArray_DATA(imgxy) + j * (long)PyArray_STRIDES(imgxy)[0] + (long)PyArray_STRIDES(imgxy)[1])
+           - (*(float *)PyArray_DATA(refxy) + k * (long)PyArray_STRIDES(refxy)[0] + (long)PyArray_STRIDES(refxy)[1]);
 
-        //dx = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]) - *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]);
-        //dy = *(float *)(PyArray_DATA(imgxy) + j*PyArray_STRIDES(imgxy)[0]+ PyArray_STRIDES(imgxy)[1]) -
-        //     *(float *)(PyArray_DATA(refxy) + k*PyArray_STRIDES(refxy)[0]+ PyArray_STRIDES(refxy)[1]);
         if ((fabs(dx) < searchrad) && (fabs(dy) < searchrad)) {
             xind = (integer_t)(dx+searchrad);
             yind = (integer_t)(dy+searchrad);

--- a/src/carrutils.c
+++ b/src/carrutils.c
@@ -96,11 +96,10 @@ arrxyzero(PyObject *obj, PyObject *args)
   for (j=0; j< imgnum; j++){
     /* compute the delta relative to each source in ref image */
     for (k = 0; k < refnum; k++){
-        dx = (*(float *)PyArray_DATA(imgxy) + j * (long)PyArray_STRIDES(imgxy)[0])
-           - (*(float *)PyArray_DATA(refxy) + k * (long)PyArray_STRIDES(refxy)[0]);
-
-        dy = (*(float *)PyArray_DATA(imgxy) + j * (long)PyArray_STRIDES(imgxy)[0] + (long)PyArray_STRIDES(imgxy)[1])
-           - (*(float *)PyArray_DATA(refxy) + k * (long)PyArray_STRIDES(refxy)[0] + (long)PyArray_STRIDES(refxy)[1]);
+        dx = *((float *)PyArray_DATA(imgxy) + j * (long)PyArray_STRIDES(imgxy)[0])
+           - *((float *)PyArray_DATA(refxy) + k * (long)PyArray_STRIDES(refxy)[0]);
+        dy = *((float *)PyArray_DATA(imgxy) + j * (long)PyArray_STRIDES(imgxy)[0] + (long)PyArray_STRIDES(imgxy)[1])
+           - *((float *)PyArray_DATA(refxy) + k * (long)PyArray_STRIDES(refxy)[0] + (long)PyArray_STRIDES(refxy)[1]);
 
         if ((fabs(dx) < searchrad) && (fabs(dy) < searchrad)) {
             xind = (integer_t)(dx+searchrad);


### PR DESCRIPTION
## Before
Seen here: https://dev.azure.com/spacetelescope/drizzlepac/_build/results?buildId=22&view=logs&jobId=bfe8a88d-3928-550a-8c7c-c7cdeca2abfc&taskId=41b9b801-0fbe-5309-8a48-81b7a46eae1f&lineStart=173&lineEnd=183&colStart=1&colEnd=1
```
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DNUMPY=1 -D_CRT_SECURE_NO_WARNING -D__STDC__=1 -IC:\Users\VSSADM~1\AppData\Local\Temp\pip-build-env-8tibd8q1\overlay\Lib\site-packages\numpy\core\include -IC:\hostedtoolcache\windows\Python\3.7.2\x64\include -IC:\hostedtoolcache\windows\Python\3.7.2\x64\include "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\cppwinrt" /Tcsrc/carrutils.c /Fobuild\temp.win-amd64-3.7\Release\src/carrutils.obj
  carrutils.c
  src/carrutils.c(40): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
  src/carrutils.c(41): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
  src/carrutils.c(92): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
  src/carrutils.c(93): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
  src/carrutils.c(99): error C2036: 'void *': unknown size
  src/carrutils.c(100): error C2036: 'void *': unknown size
  src/carrutils.c(101): error C2036: 'void *': unknown size
  error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\VC\\Tools\\MSVC\\14.16.27023\\bin\\HostX86\\x64\\cl.exe' failed with exit status 2
```

## After breaking the code out and recasting a bit
```
(tweakvenv) C:\Users\jhunk\Downloads\tweakwcs>python setup.py build_ext
running build_ext
building 'tweakwcs.chelp' extension
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DNUMPY=1 -D_CRT_SECURE_NO_WARNING -D__STDC__=1 -IC:\Users\jhunk\Downloads\tweakvenv\lib\site-packages\numpy\core\include -IC:\Users\jhunk\Downloads\tweakvenv\include -IC:\Users\jhunk\AppData\Local\Programs\Python\Python37\include -IC:\Users\jhunk\AppData\Local\Programs\Python\Python37\include "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\winrt" "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\winrt" /Tcsrc/carrutils.c /Fobuild\temp.win-amd64-3.7\Release\src/carrutils.obj
carrutils.c
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\bin\HostX86\x64\link.exe /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\jhunk\Downloads\tweakvenv\libs /LIBPATH:C:\Users\jhunk\AppData\Local\Programs\Python\Python37\libs /LIBPATH:C:\Users\jhunk\AppData\Local\Programs\Python\Python37 /LIBPATH:C:\Users\jhunk\Downloads\tweakvenv\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\ATLMFC\lib\x64" "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\lib\um\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.16299.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.16299.0\um\x64" "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\ATLMFC\lib\x86" "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\lib\x86" "/LIBPATH:C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\lib\um\x86" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.16299.0\ucrt\x86" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.16299.0\um\x86" /EXPORT:PyInit_chelp build\temp.win-amd64-3.7\Release\src/carrutils.obj /OUT:build\lib.win-amd64-3.7\tweakwcs\chelp.cp37-win_amd64.pyd /IMPLIB:build\temp.win-amd64-3.7\Release\src\chelp.cp37-win_amd64.lib
   Creating library build\temp.win-amd64-3.7\Release\src\chelp.cp37-win_amd64.lib and object build\temp.win-amd64-3.7\Release\src\chelp.cp37-win_amd64.exp
Generating code
Finished generating code```