### PR TITLE
Azure: Show pip freeze output

### DIFF
--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -48,6 +48,10 @@ jobs:
       displayName: build package
 
     - script: |
+        python -m pip freeze
+      displayName: freeze output
+
+    - script: |
         pytest --cov=./ -v --junitxml=junit/test-results.xml
       displayName: run test
 


### PR DESCRIPTION
Makes it easier to cherry-pick the environment from a build log