### PR TITLE
change indexing in model parameters

### DIFF
--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -152,7 +152,7 @@ class DetToV2V3(Model):
         yt = self.__class__.r0 * y  # / zr
         zt = np.full_like(x, self.__class__.r0)
 
-        # "unrotate" cartezian coordinates back to twc.heir original
+        # "unrotate" cartezian coordinates back to their original
         # v2ref, v3ref, and roll "positions":
         zcr, xcr, ycr = np.dot(inv_euler_rot, (zt, xt, yt))
 

--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -154,12 +154,12 @@ class DetToV2V3(Model):
 
         # "unrotate" cartezian coordinates back to their original
         # v2ref, v3ref, and roll "positions":
-        zcr, xcr, ycr = np.dot(inv_euler_rot, (zt, xt, yt))
+        zcr, xcr, ycr = np.dot(inv_euler_rot, (zt.ravel(), xt.ravel(), yt.ravel()))
 
         # convert cartesian to spherical coordinates:
         v2, v3 = self.cartesian2spherical(zcr, xcr, ycr)
 
-        return v2, v3
+        return self.prepare_outputs(format_info, v2.reshape(x.shape), v3.reshape(y.shape))
 
     @property
     def inverse(self):
@@ -601,7 +601,8 @@ class TPCorr(Model):
 
         # convert cartesian to spherical coordinates:
         v2c, v3c = self.cartesian2spherical(zcr, xcr, ycr)
-        return v2c, v3c
+
+        return v2c.reshape(v2.shape), v3c.reshape(v3.shape)
 
     @property
     def inverse(self):

--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -152,15 +152,14 @@ class DetToV2V3(Model):
         yt = self.__class__.r0 * y  # / zr
         zt = np.full_like(x, self.__class__.r0)
 
-        # "unrotate" cartezian coordinates back to their original
+        # "unrotate" cartezian coordinates back to twc.heir original
         # v2ref, v3ref, and roll "positions":
         zcr, xcr, ycr = np.dot(inv_euler_rot, (zt, xt, yt))
 
         # convert cartesian to spherical coordinates:
         v2, v3 = self.cartesian2spherical(zcr, xcr, ycr)
 
-        return self.prepare_outputs(format_info, v2.reshape(x.shape),
-                                    v3.reshape(y.shape))
+        return v2, v3
 
     @property
     def inverse(self):
@@ -266,7 +265,6 @@ class V2V3ToDet(Model):
         Evaluate the model on some input variables.
 
         """
-        (v2, v3), format_info = self.prepare_inputs(v2, v3)
 
         # convert spherical coordinates to cartesian assuming unit sphere:
         xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
@@ -291,8 +289,7 @@ class V2V3ToDet(Model):
         x += shift[0][0]
         y += shift[0][1]
 
-        return self.prepare_outputs(format_info, x.reshape(v2.shape),
-                                    y.reshape(v3.shape))
+        return x, y
 
     @property
     def inverse(self):
@@ -350,7 +347,6 @@ class V2V3ToSky(Model):
 
     def evaluate(self, v2, v3, angles):
         """ Evaluate the model on some input variables. """
-        (v2, v3), format_info = self.prepare_inputs(v2, v3)
 
         # convert spherical coordinates to cartesian assuming unit sphere:
         xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
@@ -367,13 +363,12 @@ class V2V3ToSky(Model):
         # convert cartesian to spherical coordinates:
         ra, dec = self.cartesian2spherical(z, x, y)
 
-        return self.prepare_outputs(format_info, ra.reshape(v2.shape),
-                                    dec.reshape(v3.shape))
+        return ra, dec
 
     @property
     def inverse(self):
         return self.__class__(
-            [-a for a in self.angles[0][::-1]], self.axes_order[::-1]
+            [-a for a in self.angles.value[::-1]], self.axes_order[::-1]
         )
 
 
@@ -533,9 +528,9 @@ class TPCorr(Model):
         # apply corrections:
         # NOTE: order of transforms may need to be swapped depending on the
         #       how shifts are defined.
-        xt -= self.shift[0][0]
-        yt -= self.shift[0][1]
-        xt, yt = np.dot(self.matrix[0], (xt, yt))
+        xt -= self.shift.value[0]
+        yt -= self.shift.value[1]
+        xt, yt = np.dot(self.matrix, (xt, yt))
 
         return self.prepare_outputs(format_info, xt.reshape(v2.shape),
                                     yt.reshape(v3.shape))
@@ -547,9 +542,9 @@ class TPCorr(Model):
         zt = np.full_like(xt, self.__class__.r0)
 
         # undo corrections:
-        xt, yt = np.dot(np.linalg.inv(self.matrix[0]), (xt, yt))
-        xt += self.shift[0][0]
-        yt += self.shift[0][1]
+        xt, yt = np.dot(np.linalg.inv(self.matrix), (xt, yt))
+        xt += self.shift.value[0]
+        yt += self.shift.value[1]
 
         # build Euler rotation matrices:
         rotm = [
@@ -572,15 +567,15 @@ class TPCorr(Model):
                                     v3c.reshape(yt.shape))
 
     def evaluate(self, v2, v3, v2ref, v3ref, roll, matrix, shift):
+
         """ Evaluate the model on some input variables. """
-        (v2, v3), format_info = self.prepare_inputs(v2, v3)
 
         # convert spherical coordinates to cartesian assuming unit sphere:
         xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
 
         # build Euler rotation matrices:
         rotm = [rot_mat3d(np.deg2rad(alpha), axis)
-                for axis, alpha in enumerate([roll[0], v3ref[0], v2ref[0]])]
+                for axis, alpha in enumerate([roll, v3ref, v2ref])]
         euler_rot = np.linalg.multi_dot(rotm)
         inv_euler_rot = np.linalg.inv(euler_rot)
 
@@ -606,9 +601,7 @@ class TPCorr(Model):
 
         # convert cartesian to spherical coordinates:
         v2c, v3c = self.cartesian2spherical(zcr, xcr, ycr)
-
-        return self.prepare_outputs(format_info, v2c.reshape(v2.shape),
-                                    v3c.reshape(v3.shape))
+        return v2c, v3c
 
     @property
     def inverse(self):

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -242,23 +242,66 @@ def test_jwstgwcs_ref_angles_preserved(tpcorr, mock_jwst_wcs):
     assert wc.ref_angles['v3_ref'] == 500.0
     assert wc.ref_angles['roll_ref'] == 115.0
 
+# Test inputs with different shapes
 
-@pytest.mark.parametrize('tpcorr', _TPCORRS)
-def test_jwstgwcs_coord_transforms(tpcorr):
-    tpwcs.TPCorr = tpcorr
-    w = make_mock_jwst_wcs(
-        v2ref=0.0, v3ref=0.0, roll=0.0, crpix=[500.0, 512.0],
-        cd=[[1.0e-5, 0.0], [0.0, 1.0e-5]], crval=[12.0, 24.0]
-    )
-    wc = tpwcs.JWSTgWCS(w, {'v2_ref': 0.0, 'v3_ref': 0.0, 'roll_ref': 0.0})
-    wc.set_correction()
+@pytest.mark.parametrize('inputs', [[500, 512, 12, 24],
+                                    [[500, 500], [512, 512], [12, 12], [24, 24]],
+                                    [[[500, 500], [500, 500]],
+                                     [[512, 512], [512, 512]],
+                                     [[12, 12], [12, 12]], [[24, 24], [24, 24]]]
+                                    ])
+def test_jwstgwcs_detector_to_world(inputs):
+    for tpcorr in _TPCORRS:
+        tpwcs.TPCorr = tpcorr
+        w = make_mock_jwst_wcs(
+            v2ref=0.0, v3ref=0.0, roll=0.0, crpix=[500.0, 512.0],
+            cd=[[1.0e-5, 0.0], [0.0, 1.0e-5]], crval=[12.0, 24.0]
+        )
+        wc = tpwcs.JWSTgWCS(w, {'v2_ref': 0.0, 'v3_ref': 0.0, 'roll_ref': 0.0})
+        wc.set_correction()
+        x, y, ra, dec = inputs
+        assert np.allclose(wc.det_to_world(x, y), (ra, dec), atol=_ATOL)
+        assert np.allclose(wc.world_to_det(ra, dec), (x, y), atol=_ATOL)
 
-    assert np.allclose(wc.det_to_world(500, 512), (12, 24), atol=_ATOL)
-    assert np.allclose(wc.world_to_det(12, 24), (500, 512), atol=_ATOL)
-    assert np.allclose(wc.det_to_tanp(500, 512), (0, 0), atol=_ATOL)
-    assert np.allclose(wc.tanp_to_det(0, 0), (500, 512), atol=_ATOL)
-    assert np.allclose(wc.world_to_tanp(12, 24), (0, 0), atol=_ATOL)
-    assert np.allclose(wc.tanp_to_world(0, 0), (12, 24), atol=_ATOL)
+
+@pytest.mark.parametrize('inputs', [[0, 0, 12, 24],
+                                    [[0, 0], [0, 0], [12, 12], [24, 24]],
+                                    [[[0, 0],[0, 0]],
+                                     [[0, 0], [0, 0]],
+                                     [[12, 12], [12, 12]], [[24, 24], [24, 24]]]
+                                    ])
+def test_jwstgwcs_tangent_to_world(inputs):
+    for tpcorr in _TPCORRS:
+        tpwcs.TPCorr = tpcorr
+        w = make_mock_jwst_wcs(
+            v2ref=0.0, v3ref=0.0, roll=0.0, crpix=[500.0, 512.0],
+            cd=[[1.0e-5, 0.0], [0.0, 1.0e-5]], crval=[12.0, 24.0]
+        )
+        wc = tpwcs.JWSTgWCS(w, {'v2_ref': 0.0, 'v3_ref': 0.0, 'roll_ref': 0.0})
+        wc.set_correction()
+        tanp_x, tanp_y, ra, dec = inputs
+        assert np.allclose(wc.world_to_tanp(ra, dec), (tanp_x, tanp_y), atol=_ATOL)
+        assert np.allclose(wc.tanp_to_world(tanp_x, tanp_y), (ra, dec), atol=_ATOL)
+
+
+@pytest.mark.parametrize('inputs', [[500, 512, 0, 0],
+                                    [[500, 500], [512, 512], [0, 0], [0, 0]],
+                                    [[[500, 500], [500, 500]],
+                                     [[512, 512], [512, 512]],
+                                     [[0, 0], [0, 0]], [[0, 0], [0, 0]]]
+                                    ])
+def test_jwstgwcs_detector_to_tanp(inputs):
+    for tpcorr in _TPCORRS:
+        tpwcs.TPCorr = tpcorr
+        w = make_mock_jwst_wcs(
+            v2ref=0.0, v3ref=0.0, roll=0.0, crpix=[500.0, 512.0],
+            cd=[[1.0e-5, 0.0], [0.0, 1.0e-5]], crval=[12.0, 24.0]
+        )
+        wc = tpwcs.JWSTgWCS(w, {'v2_ref': 0.0, 'v3_ref': 0.0, 'roll_ref': 0.0})
+        wc.set_correction()
+        x, y, tanp_x, tanp_y = inputs
+        assert np.allclose(wc.det_to_tanp(x, y), (tanp_x, tanp_y), atol=_ATOL)
+        assert np.allclose(wc.tanp_to_det(tanp_x, tanp_y), (x, y), atol=_ATOL)
 
 
 @pytest.mark.parametrize('tpcorr', _TPCORRS)

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -244,6 +244,7 @@ def test_jwstgwcs_ref_angles_preserved(tpcorr, mock_jwst_wcs):
 
 # Test inputs with different shapes
 
+
 @pytest.mark.parametrize('inputs', [[500, 512, 12, 24],
                                     [[500, 500], [512, 512], [12, 12], [24, 24]],
                                     [[[500, 500], [500, 500]],
@@ -266,7 +267,7 @@ def test_jwstgwcs_detector_to_world(inputs):
 
 @pytest.mark.parametrize('inputs', [[0, 0, 12, 24],
                                     [[0, 0], [0, 0], [12, 12], [24, 24]],
-                                    [[[0, 0],[0, 0]],
+                                    [[[0, 0], [0, 0]],
                                      [[0, 0], [0, 0]],
                                      [[12, 12], [12, 12]], [[24, 24], [24, 24]]]
                                     ])


### PR DESCRIPTION
Instead of indexing `model.Parameter` index the value of the parameter.
This removes ambiguity in the current code where indexing is of a `Parameter` instance returns one parameter in a model set. With this changes the code works with current astropy.modeling master and the future refactored modeling.

In addition the `prepare_inputs/outputs` calls were removed as they are not necessary in this case.