### PR TITLE
Azure: Require jwst package (master)

### DIFF
--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -41,6 +41,7 @@ jobs:
       # Some namespace packages require but do not provide stsci.distutils.
     - script: |
         $(PIP_INSTALL) pip numpy stsci.distutils d2to1
+        $(PIP_INSTALL) git+https://github.com/spacetelescope/jwst
       displayName: install dependencies
 
     - script: |


### PR DESCRIPTION
This allows pipeline related tests to execute.

~Note: `stable` branch may be significantly behind `master`.~ Cannot use `stable` branch at this time. The previous release of `jwst` was incompatible with MSVC.