### PR TITLE
Fix logging and add group name deduction logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@
 Release Notes
 =============
 
-.. 0.5.2 (unreleased)
+.. 0.5.3 (unreleased)
    ==================
+
+0.5.2 (26-July-2019)
+====================
+
+- Fixed a deprecation issue in logging and added logic to compute image group
+  name using a common prefix (if exists) of the names of constituent
+  images. [#92]
 
 0.5.1 (08-May-2019)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,8 @@ Release Notes
 0.5.2 (26-July-2019)
 ====================
 
-- Fixed a deprecation issue in logging and added logic to compute image group
-  name using a common prefix (if exists) of the names of constituent
+- Fixed a deprecation issue in logging and added logic to compute image group's
+  catalog name using a common prefix (if exists) of the names of constituent
   images. [#92]
 
 0.5.1 (08-May-2019)

--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -338,8 +338,8 @@ def _estimate_2dhist_shift(imgxy, refxy, searchrad=3.0):
                  .format(xp, yp, sig, flux))
 
     else:
-        log.warn("Unable to estimate significance of the detection of the "
-                 "initial shift.")
+        log.warning("Unable to estimate significance of the detection of the "
+                    "initial shift.")
         log.info("Found initial X and Y shifts of {:.4g}, {:.4g} "
                  "with {:d} matches."
                  .format(xp, yp, flux))

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -677,7 +677,6 @@ class WCSGroupCatalog(object):
 
         return cat
 
-
     def get_unmatched_cat(self):
         """
         Retrieve only those sources from the catalog that have **not** been

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -9,6 +9,7 @@ source catalogs.
 
 """
 # STDLIB
+import os
 import logging
 import numbers
 from copy import deepcopy
@@ -585,10 +586,17 @@ class WCSGroupCatalog(object):
         catalogs = []
         catno = 0
         has_weights = None
+        cat_names = []
         for image in self._images:
             catlen = len(image.catalog)
             if catlen == 0:
                 continue
+
+            cat_name = image.catalog.meta.get(
+                'name',
+                image.name if image.name else 'Unnamed'
+            )
+            cat_names.append(cat_name)
 
             if has_weights is None:
                 has_weights = 'weight' in image.catalog.colnames
@@ -634,7 +642,12 @@ class WCSGroupCatalog(object):
             catalogs.append(cat)
             catno += 1
 
-        if not catno:
+        catname = os.path.commonprefix(cat_names) if cat_names else None
+
+        if catno:
+            cat = table.vstack(catalogs, join_type='exact')
+
+        else:
             # no catalogs with sources. Create an empty table with required
             # columns and types:
             image = self._images[0]
@@ -659,9 +672,11 @@ class WCSGroupCatalog(object):
                 masked=True
             )
 
-            return cat
+        if catname:
+            cat.meta['name'] = catname
 
-        return table.vstack(catalogs, join_type='exact')
+        return cat
+
 
     def get_unmatched_cat(self):
         """


### PR DESCRIPTION
This PR fixes logging deprecation warnings and adds logic to compute image group's **catalog**
  name using a common prefix (if exists) of the names of constituent images/catalogs.