### PR TITLE
Allow some empty input catalogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@
 Release Notes
 =============
 
-.. 0.5.3 (unreleased)
+.. 0.5.4 (unreleased)
    ==================
+
+0.5.3 (15-November-2019)
+========================
+
+- Added logic to allow some input catalogs to be empty and to allow the
+  alignment to proceed as long as there are at least two non-empty
+  (image or group) input catalogs. [#94]
 
 0.5.2 (26-July-2019)
 ====================

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -522,16 +522,27 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
                 )
 
         else:
-            wcs_gcat.append(
-                WCSGroupCatalog(
-                    wcatalogs,
-                    name='GROUP ID: {}'.format(group_id)
-                )
+            gcat = WCSGroupCatalog(
+                wcatalogs,
+                name='GROUP ID: {}'.format(group_id)
             )
+            if not len(gcat.catalog):
+                log.warning("Group with ID '{}' will not be aligned: empty "
+                            "source catalog".format(group_id))
+
+                for wcat in wcatalogs:
+                    wcat.tpwcs.meta['fit_info'] = {
+                        'status': 'FAILED: empty source catalog'
+                    }
+
+                continue
+
+            wcs_gcat.append(gcat)
 
     # check that we have enough input images:
     if (refcat is None and len(wcs_gcat) < 2) or len(wcs_gcat) == 0:
-        raise ValueError("Too few input images (or groups of images).")
+        raise ValueError("Too few input images (or groups of images) with "
+                         "non-empty catalogs.")
 
     # get the first image to be aligned and
     # create reference catalog if needed:

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -195,9 +195,6 @@ class WCSImageCatalog(object):
             raise ValueError("An image catalog must contain 'x' and 'y' "
                              "columns!")
 
-        if not catalog:
-            raise ValueError("Image catalog must contain at least one entry.")
-
         self._catalog = table.Table(catalog.copy(), masked=True)
         self._catalog.meta['name'] = self._name
 
@@ -381,6 +378,7 @@ class WCSImageCatalog(object):
 
         self.img_bounding_ra = ra
         self.img_bounding_dec = dec
+        self._bb_radec = (ra, dec)
         self._polygon = SphericalPolygon.from_radec(ra, dec)
 
     def _calc_cat_convex_hull(self):


### PR DESCRIPTION
Original code was too restrictive: it _required_ all input images to have non-empty source catalogs. This PR relaxes this requirement and allows alignment to proceed as long as there are enough images with non-empty catalogs.

This PR fixes https://github.com/spacetelescope/jwst/issues/4261 