### PR TITLE
Replace TPCorr with standard astropy/gwcs models in the JWST WCS corrector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,17 @@
 Release Notes
 =============
 
-.. 0.5.4 (unreleased)
+.. 0.6.1 (unreleased)
    ==================
+
+
+0.6.0 (unreleased)
+==================
+
+- Re-designed the ``JWSTgWCS`` corrector class to rely exclusively on
+  basic models available in ``astropy`` and ``gwcs`` instead of the ``TPCorr``
+  class provided by the ``jwst`` pipeline. This eliminates the need to install
+  the ``jwst`` pipeline in order to align ``JWST`` images. [#96]
 
 0.5.3 (15-November-2019)
 ========================

--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -5,13 +5,21 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import math
+from distutils.version import LooseVersion
+
 import numpy as np
-from astropy.modeling import Model, Parameter, InputParameterError
+from astropy.modeling import Model, Parameter
+from astropy.modeling.models import AffineTransformation2D
 from astropy import coordinates as coord
 from astropy import units as u
 import gwcs
 
-from tweakwcs.tpwcs import TPWCS
+if LooseVersion(gwcs.__version__) > '0.12.0':
+    from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
+    _S2C = SphericalToCartesian(name='s2c')
+    _C2S = CartesianToSpherical(name='c2s')
+
+from tweakwcs.tpwcs import TPWCS, JWSTgWCS
 
 
 class DummyTPWCS(TPWCS):
@@ -47,277 +55,50 @@ def rot_mat3d(angle, axis):
     return np.insert(np.insert(mat2d, axis, [0.0, 0.0], 1), axis, axisv, 0)
 
 
-class DetToV2V3(Model):
-    """
-    Apply ``V2ref``, ``V3ref``, and ``roll`` to input angles and project
-    the point from the tangent plane onto a celestial sphere.
+def create_DetToV2V3(v2ref=0.0, v3ref=0.0, roll=0.0,
+                     cd=[[1.0, 0.0], [0.0, 1.0]], crpix=[0, 0]):
+    tpcorr = JWSTgWCS._tpcorr_init(v2_ref=v2ref, v3_ref=v3ref, roll_ref=roll)
 
-    Parameters
-    ----------
-    v2ref : float
-        V2 position of the reference point in degrees. Default is 0 degrees.
+    afinv = AffineTransformation2D(cd, -np.dot(cd, crpix)).inverse
 
-    v3ref : float
-        V3 position of the reference point in degrees. Default is 0 degrees.
+    JWSTgWCS._tpcorr_combine_affines(
+        tpcorr,
+        afinv.matrix.value,
+        afinv.translation.value
+    )
 
-    roll : float
-        Roll angle in degrees. Default is 0 degrees.
+    p = JWSTgWCS._v2v3_to_tpcorr_from_full(tpcorr)
+    partial_tpcorr = p.inverse
+    partial_tpcorr.inverse = p
 
-    """
-    v2ref = Parameter(default=0.0)
-    v3ref = Parameter(default=0.0)
-    roll = Parameter(default=0.0)
-    cd = Parameter(default=[[1.0, 0.0], [0.0, 1.0]])
-    crpix = Parameter(default=[0.0, 0.0])
-
-    inputs = ('x', 'y')
-    outputs = ('v2', 'v3')
-
-    _separable = False
-    standard_broadcasting = False
-
-    r0 = 1  # 3600.0 * np.rad2deg(1.0)
-    """
-    Radius of the generating sphere. This sets the circumference to 360 deg
-    so that arc length is measured in deg.
-    """
-
-    def __init__(self, v2ref=v2ref.default, v3ref=v3ref.default,
-                 roll=roll.default, cd=cd.default,
-                 crpix=crpix.default, **kwargs):
-        super().__init__(
-            v2ref=v2ref, v3ref=v3ref, roll=roll, cd=cd,
-            crpix=crpix, **kwargs
-        )
-
-    @property
-    def input_units(self):
-        return {'x': None, 'y': None}
-
-    @property
-    def return_units(self):
-        return {'v2': None, 'v3': None}
-
-    @cd.validator
-    def cd(self, value):
-        """ Validates that the input CD matrix is a 2x2 2D array. """
-        if np.shape(value) != (2, 2):
-            raise InputParameterError(
-                "Expected CD matrix to be a 2x2 array")
-
-    @crpix.validator
-    def crpix(self, value):
-        """
-        Validates that the crpix vector is a 2D vector.  This allows
-        either a "row" vector.
-
-        """
-        if not (np.ndim(value) == 1 and np.shape(value) == (2,)):
-            raise InputParameterError(
-                "Expected 'crpix' to be a 2 element row vector."
-            )
-
-    @staticmethod
-    def cartesian2spherical(x, y, z):
-        """
-        Convert cartesian coordinates to spherical coordinates (in acrsec).
-
-        """
-        h = np.hypot(x, y)
-        alpha = np.rad2deg(np.arctan2(y, x))
-        delta = np.rad2deg(np.arctan2(z, h))
-        return alpha, delta
-
-    def evaluate(self, x, y, v2ref, v3ref, roll, cd, crpix):
-        """
-        Evaluate the model on some input variables.
-
-        """
-        (x, y), format_info = self.prepare_inputs(x, y)
-
-        # build Euler rotation matrices:
-        rotm = [rot_mat3d(np.deg2rad(alpha), axis)
-                for axis, alpha in enumerate([roll[0], v3ref[0], v2ref[0]])]
-        euler_rot = np.linalg.multi_dot(rotm)
-        inv_euler_rot = np.linalg.inv(euler_rot)
-
-        # apply corrections:
-        # NOTE: order of transforms may need to be swapped depending on
-        #       how shifts are defined.
-        x -= crpix[0][0]
-        y -= crpix[0][1]
-        x, y = np.dot(cd[0].T, (x, y))
-
-        xt = self.__class__.r0 * x  # / zr
-        yt = self.__class__.r0 * y  # / zr
-        zt = np.full_like(x, self.__class__.r0)
-
-        # "unrotate" cartezian coordinates back to their original
-        # v2ref, v3ref, and roll "positions":
-        zcr, xcr, ycr = np.dot(inv_euler_rot, (zt.ravel(), xt.ravel(), yt.ravel()))
-
-        # convert cartesian to spherical coordinates:
-        v2, v3 = self.cartesian2spherical(zcr, xcr, ycr)
-
-        return self.prepare_outputs(format_info, v2.reshape(x.shape), v3.reshape(y.shape))
-
-    @property
-    def inverse(self):
-        """
-        Returns a new `TPCorr` instance which performs the inverse
-        transformation of the transformation defined for this `TPCorr` model.
-
-        """
-        return V2V3ToDet(v2ref=self.v2ref.value, v3ref=self.v3ref.value,
-                         roll=self.roll.value, cd=self.cd.value,
-                         crpix=self.crpix.value)
+    return partial_tpcorr
 
 
-class V2V3ToDet(Model):
-    """
-    Apply ``V2ref``, ``V3ref``, and ``roll`` to input angles and project
-    the point from the tangent plane onto a celestial sphere.
-
-    Parameters
-    ----------
-    v2ref : float
-        V2 position of the reference point in degrees. Default is 0 degrees.
-
-    v3ref : float
-        V3 position of the reference point in degrees. Default is 0 degrees.
-
-    roll : float
-        Roll angle in degrees. Default is 0 degrees.
-
-    """
-    v2ref = Parameter(default=0.0)
-    v3ref = Parameter(default=0.0)
-    roll = Parameter(default=0.0)
-    cd = Parameter(default=[[1.0, 0.0], [0.0, 1.0]])
-    crpix = Parameter(default=[0.0, 0.0])
-
-    inputs = ('v2', 'v3')
-    outputs = ('x', 'y')
-
-    # input_units_strict = False
-    # input_units_allow_dimensionless = True
-    _separable = False
-    standard_broadcasting = False
-
-    r0 = 1  # 3600.0 * np.rad2deg(1.0)
-    """
-    Radius of the generating sphere. This sets the circumference to 360 deg
-    so that arc length is measured in deg.
-    """
-    def __init__(self, v2ref=v2ref.default, v3ref=v3ref.default,
-                 roll=roll.default, cd=cd.default,
-                 crpix=crpix.default, **kwargs):
-        super().__init__(
-            v2ref=v2ref, v3ref=v3ref, roll=roll, cd=cd,
-            crpix=crpix, **kwargs
-        )
-
-    @property
-    def input_units(self):
-        return {'v2': None, 'v3': None}
-
-    @property
-    def return_units(self):
-        return {'x': None, 'y': None}
-
-    @cd.validator
-    def cd(self, value):
-        """
-        Validates that the input CD matrix is a 2x2 2D array.
-
-        """
-        if np.shape(value) != (2, 2):
-            raise InputParameterError(
-                "Expected CD matrix to be a 2x2 array")
-
-    @crpix.validator
-    def crpix(self, value):
-        """
-        Validates that the crpix vector is a 2D vector.  This allows
-        either a "row" vector.
-
-        """
-        if not (np.ndim(value) == 1 and np.shape(value) == (2,)):
-            raise InputParameterError(
-                "Expected 'crpix' to be a 2 element row vector."
-            )
-
-    @staticmethod
-    def spherical2cartesian(alpha, delta):
-        """
-        Convert spherical coordinates (in arcsec) to cartesian.
-
-        """
-        alpha = np.deg2rad(alpha)
-        delta = np.deg2rad(delta)
-        x = np.cos(alpha) * np.cos(delta)
-        y = np.cos(delta) * np.sin(alpha)
-        z = np.sin(delta)
-        return x, y, z
-
-    def evaluate(self, v2, v3, v2ref, v3ref, roll, cd, shift):
-        """
-        Evaluate the model on some input variables.
-
-        """
-
-        # convert spherical coordinates to cartesian assuming unit sphere:
-        xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
-
-        # build Euler rotation matrices:
-        rotm = [rot_mat3d(np.deg2rad(alpha), axis)
-                for axis, alpha in enumerate([roll[0], v3ref[0], v2ref[0]])]
-        euler_rot = np.linalg.multi_dot(rotm)
-
-        # rotate cartezian coordinates:
-        zr, xr, yr = np.dot(euler_rot, xyz)
-
-        # project points onto the tanject plane
-        # (tangent to a sphere of radius r0):
-        xt = self.__class__.r0 * xr / zr
-        yt = self.__class__.r0 * yr / zr
-
-        # apply corrections:
-        # NOTE: order of transforms may need to be swapped depending on
-        #       how shifts are defined.
-        x, y = np.dot(np.linalg.inv(cd[0]).T, (xt, yt))
-        x += shift[0][0]
-        y += shift[0][1]
-
-        return x, y
-
-    @property
-    def inverse(self):
-        """
-        Returns a new `TPCorr` instance which performs the inverse
-        transformation of the transformation defined for this `TPCorr` model.
-
-        """
-        return DetToV2V3(v2ref=self.v2ref.value, v3ref=self.v3ref.value,
-                         roll=self.roll.value, cd=self.cd.value,
-                         crpix=self.crpix.value)
+def create_V2V3ToDet(v2ref=0.0, v3ref=0.0, roll=0.0,
+                     cd=[[1.0, 0.0], [0.0, 1.0]], crpix=[0, 0]):
+    inv_partial_tpcorr = create_DetToV2V3(
+        v2ref=v2ref, v3ref=v3ref, roll=roll, crpix=crpix, cd=cd
+    ).inverse
+    return inv_partial_tpcorr
 
 
 class V2V3ToSky(Model):
     """
     Rotates V2-V3 sphere on the sky.
     """
-    inputs = ("v2", "v3")
-    outputs = ("ra", "dec")
-
     angles = Parameter()
 
     _separable = False
     standard_broadcasting = False
 
+    n_inputs = 2
+    n_outputs = 2
+
     def __init__(self, angles, axes_order, name=None):
         self.axes_order = axes_order
         super().__init__(angles=angles, name=name)
+        self.inputs = ("v2", "v3")
+        self.outputs = ("ra", "dec")
 
     @staticmethod
     def build_euler_matrix(axis_angle):
@@ -329,27 +110,19 @@ class V2V3ToSky(Model):
 
     @staticmethod
     def cartesian2spherical(x, y, z):
-        """ Convert cartesian coordinates to spherical (in acrsec). """
-        h = np.hypot(x, y)
-        alpha = np.rad2deg(np.arctan2(y, x))
-        delta = np.rad2deg(np.arctan2(z, h))
-        return alpha, delta
+        """ Convert cartesian coordinates to spherical (in deg). """
+        return _C2S(x, y, z)
 
     @staticmethod
     def spherical2cartesian(alpha, delta):
-        """ Convert spherical coordinates (in arcsec) to cartesian. """
-        alpha = np.deg2rad(alpha)
-        delta = np.deg2rad(delta)
-        x = np.cos(alpha) * np.cos(delta)
-        y = np.cos(delta) * np.sin(alpha)
-        z = np.sin(delta)
-        return x, y, z
+        """ Convert spherical coordinates (in deg) to cartesian. """
+        return _S2C(alpha, delta)
 
     def evaluate(self, v2, v3, angles):
         """ Evaluate the model on some input variables. """
 
         # convert spherical coordinates to cartesian assuming unit sphere:
-        xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
+        xyz = self.spherical2cartesian(v2.ravel() / 3600., v3.ravel() / 3600.0)
 
         # build Euler rotation matrices:
         euler_rot = self.__class__.build_euler_matrix(
@@ -367,9 +140,68 @@ class V2V3ToSky(Model):
 
     @property
     def inverse(self):
-        return self.__class__(
-            [-a for a in self.angles.value[::-1]], self.axes_order[::-1]
+        return V2V3ToSkyInv(self.angles.value, self.axes_order)
+
+
+class V2V3ToSkyInv(Model):
+    """
+    Rotates V2-V3 sphere on the sky.
+    """
+    angles = Parameter()
+
+    _separable = False
+    standard_broadcasting = False
+
+    n_inputs = 2
+    n_outputs = 2
+
+    def __init__(self, angles, axes_order, name=None):
+        self.axes_order = axes_order
+        super().__init__(angles=angles, name=name)
+        self.inputs = ("v2", "v3")
+        self.outputs = ("ra", "dec")
+
+    @staticmethod
+    def build_euler_matrix(axis_angle):
+        # build Euler rotation matrices:
+        rotm = [rot_mat3d(np.deg2rad(alpha), axis)
+                for axis, alpha in axis_angle]
+        euler_rot = np.linalg.multi_dot(rotm)
+        return euler_rot
+
+    @staticmethod
+    def cartesian2spherical(x, y, z):
+        """ Convert cartesian coordinates to spherical (in deg). """
+        return _C2S(x, y, z)
+
+    @staticmethod
+    def spherical2cartesian(alpha, delta):
+        """ Convert spherical coordinates (in deg) to cartesian. """
+        return _S2C(alpha, delta)
+
+    def evaluate(self, v2, v3, angles):
+        """ Evaluate the model on some input variables. """
+
+        # convert spherical coordinates to cartesian assuming unit sphere:
+        xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
+
+        # build Euler rotation matrices:
+        euler_rot = self.__class__.build_euler_matrix(
+            [(v[0], -v[1]) if v[0] != 1 else v for v in
+             zip(self.axes_order[::-1], (-angles[0])[::-1])][::-1]
         )
+
+        # rotate cartezian coordinates:
+        z, x, y = np.dot(euler_rot, xyz)
+
+        # convert cartesian to spherical coordinates:
+        ra, dec = self.cartesian2spherical(z, x, y)
+
+        return 3600 * ra, 3600 * dec
+
+    @property
+    def inverse(self):
+        return V2V3ToSky(self.angles.value, self.axes_order)
 
 
 def make_mock_jwst_pipeline(v2ref=0, v3ref=0, roll=0, crpix=[512, 512],
@@ -382,8 +214,9 @@ def make_mock_jwst_pipeline(v2ref=0, v3ref=0, roll=0, crpix=[512, 512],
     )
     world = gwcs.coordinate_frames.CelestialFrame(reference_frame=coord.ICRS(),
                                                   name='world')
-    det2v2v3 = DetToV2V3(v2ref=v2ref / 3600.0, v3ref=v3ref / 3600.0,
-                         roll=roll, cd=cd, crpix=crpix)
+    det2v2v3 = create_DetToV2V3(v2ref=v2ref / 3600.0, v3ref=v3ref / 3600.0,
+                                roll=roll, cd=cd, crpix=crpix)
+
     v23sky = V2V3ToSky([-v2ref / 3600.0, v3ref / 3600.0, -roll,
                         -crval[1], crval[0]], [2, 1, 0, 1, 2])
     pipeline = [(detector, det2v2v3), (v2v3, v23sky), (world, None)]
@@ -397,261 +230,3 @@ def make_mock_jwst_wcs(v2ref=0, v3ref=0, roll=0, crpix=[512, 512],
     wcs.bounding_box = ((-0.5, 1024 - 0.5), (-0.5, 2048 - 0.5))
     wcs.array_shape = (2048, 1024)
     return wcs
-
-
-# `IncompatibleCorrections` and `TPCorr` have been copied from
-# `jwst.transforms.tpcorr` in order to provide ability to test `tpwcs` module
-# even when `jwst` package is not installed.
-class IncompatibleCorrections(Exception):
-    """
-    An exception class used to report cases when two or more tangent plane
-    corrections cannot be combined into a single one.
-    """
-    pass
-
-
-class TPCorr(Model):
-    """
-    Apply ``V2ref``, ``V3ref``, and ``roll`` to input angles and project
-    the point from the tangent plane onto a celestial sphere.
-
-    Parameters
-    ----------
-    v2ref : float
-        V2 position of the reference point in degrees. Default is 0 degrees.
-
-    v3ref : float
-        V3 position of the reference point in degrees. Default is 0 degrees.
-
-    roll : float
-        Roll angle in degrees. Default is 0 degrees.
-
-    """
-    v2ref = Parameter(default=0.0)
-    v3ref = Parameter(default=0.0)
-    roll = Parameter(default=0.0)
-    matrix = Parameter(default=[[1.0, 0.0], [0.0, 1.0]])
-    shift = Parameter(default=[0.0, 0.0])
-
-    inputs = ('v2', 'v3')
-    outputs = ('v2c', 'v3c')
-
-    # input_units_strict = False
-    # input_units_allow_dimensionless = True
-    _separable = False
-    standard_broadcasting = False
-
-    r0 = 3600.0 * np.rad2deg(1.0)
-    """
-    Radius of the generating sphere. This sets the circumference to 360 deg
-    so that arc length is measured in deg.
-    """
-
-    def __init__(self, v2ref=v2ref.default, v3ref=v3ref.default,
-                 roll=roll.default, matrix=matrix.default,
-                 shift=shift.default, **kwargs):
-        super(TPCorr, self).__init__(
-            v2ref=v2ref, v3ref=v3ref, roll=roll, matrix=matrix,
-            shift=shift, **kwargs
-        )
-
-    @property
-    def input_units(self):
-        return {'v2': None, 'v3': None}
-
-    @property
-    def return_units(self):
-        return {'v2c': None, 'v3c': None}
-
-    @matrix.validator
-    def matrix(self, value):
-        """ Validates that the input matrix is a 2x2 2D array. """
-        if np.shape(value) != (2, 2):
-            raise InputParameterError(  # pragma: no cover
-                "Expected transformation matrix to be a 2x2 array")
-
-    @shift.validator
-    def shift(self, value):
-        """
-        Validates that the shift vector is a 2D vector.  This allows
-        either a "row" vector.
-        """
-        if not (np.ndim(value) == 1 and np.shape(value) == (2,)):
-            raise InputParameterError(  # pragma: no cover
-                "Expected 'shift' to be a 2 element row vector."
-            )
-
-    @staticmethod
-    def cartesian2spherical(x, y, z):
-        """ Convert cartesian coordinates to spherical coordinates (in acrsec).
-        """
-        h = np.hypot(x, y)
-        alpha = 3600.0 * np.rad2deg(np.arctan2(y, x))
-        delta = 3600.0 * np.rad2deg(np.arctan2(z, h))
-        return alpha, delta
-
-    @staticmethod
-    def spherical2cartesian(alpha, delta):
-        """ Convert spherical coordinates (in arcsec) to cartesian. """
-        alpha = np.deg2rad(alpha / 3600.0)
-        delta = np.deg2rad(delta / 3600.0)
-        x = np.cos(alpha) * np.cos(delta)
-        y = np.cos(delta) * np.sin(alpha)
-        z = np.sin(delta)
-        return x, y, z
-
-    def v2v3_to_tanp(self, v2, v3):
-        """ Converts V2V3 spherical coordinates to tangent plane coordinates.
-        """
-        (v2, v3), format_info = self.prepare_inputs(v2, v3)
-
-        # convert spherical coordinates to cartesian assuming unit sphere:
-        xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
-
-        # build Euler rotation matrices:
-        rotm = [
-            rot_mat3d(np.deg2rad(alpha), axis)
-            for axis, alpha in enumerate(
-                [self.roll.value, self.v3ref.value, self.v2ref.value]
-            )
-        ]
-        euler_rot = np.linalg.multi_dot(rotm)
-
-        # rotate cartezian coordinates:
-        zr, xr, yr = np.dot(euler_rot, xyz)
-
-        # project points onto the tanject plane
-        # (tangent to a sphere of radius r0):
-        xt = self.__class__.r0 * xr / zr
-        yt = self.__class__.r0 * yr / zr
-
-        # apply corrections:
-        # NOTE: order of transforms may need to be swapped depending on
-        #       how shifts are defined.
-        xt -= self.shift.value[0]
-        yt -= self.shift.value[1]
-        xt, yt = np.dot(self.matrix, (xt, yt))
-
-        return self.prepare_outputs(format_info, xt.reshape(v2.shape),
-                                    yt.reshape(v3.shape))
-
-    def tanp_to_v2v3(self, xt, yt):
-        """ Converts tangent plane coordinates to V2V3 spherical coordinates.
-        """
-        (xt, yt), format_info = self.prepare_inputs(xt, yt)
-        zt = np.full_like(xt, self.__class__.r0)
-
-        # undo corrections:
-        xt, yt = np.dot(np.linalg.inv(self.matrix), (xt, yt))
-        xt += self.shift.value[0]
-        yt += self.shift.value[1]
-
-        # build Euler rotation matrices:
-        rotm = [
-            rot_mat3d(np.deg2rad(alpha), axis)
-            for axis, alpha in enumerate(
-                [self.roll.value, self.v3ref.value, self.v2ref.value]
-            )
-        ]
-        inv_euler_rot = np.linalg.inv(np.linalg.multi_dot(rotm))
-
-        # "unrotate" cartezian coordinates back to their original
-        # v2ref, v3ref, and roll "positions":
-        zcr, xcr, ycr = np.dot(inv_euler_rot, (zt.ravel(), xt.ravel(),
-                                               yt.ravel()))
-
-        # convert cartesian to spherical coordinates:
-        v2c, v3c = self.cartesian2spherical(zcr, xcr, ycr)
-
-        return self.prepare_outputs(format_info, v2c.reshape(xt.shape),
-                                    v3c.reshape(yt.shape))
-
-    def evaluate(self, v2, v3, v2ref, v3ref, roll, matrix, shift):
-
-        """ Evaluate the model on some input variables. """
-
-        # convert spherical coordinates to cartesian assuming unit sphere:
-        xyz = self.spherical2cartesian(v2.ravel(), v3.ravel())
-
-        # build Euler rotation matrices:
-        rotm = [rot_mat3d(np.deg2rad(alpha), axis)
-                for axis, alpha in enumerate([roll, v3ref, v2ref])]
-        euler_rot = np.linalg.multi_dot(rotm)
-        inv_euler_rot = np.linalg.inv(euler_rot)
-
-        # rotate cartezian coordinates:
-        zr, xr, yr = np.dot(euler_rot, xyz)
-
-        # project points onto the tanject plane
-        # (tangent to a sphere of radius r0):
-        xt = self.__class__.r0 * xr / zr
-        yt = self.__class__.r0 * yr / zr
-        zt = np.full_like(xt, self.__class__.r0)
-
-        # apply corrections:
-        # NOTE: order of transforms may need to be swapped depending on
-        #       how shifts are defined.
-        xt -= shift[0][0]
-        yt -= shift[0][1]
-        xt, yt = np.dot(matrix[0], (xt, yt))
-
-        # "unrotate" cartezian coordinates back to their original
-        # v2ref, v3ref, and roll "positions":
-        zcr, xcr, ycr = np.dot(inv_euler_rot, (zt, xt, yt))
-
-        # convert cartesian to spherical coordinates:
-        v2c, v3c = self.cartesian2spherical(zcr, xcr, ycr)
-
-        return v2c.reshape(v2.shape), v3c.reshape(v3.shape)
-
-    @property
-    def inverse(self):
-        """
-        Returns a new `TPCorr` instance which performs the inverse
-        transformation of the transformation defined for this `TPCorr` model.
-
-        """
-        ishift = -np.dot(self.matrix.value, self.shift.value)
-        imatrix = np.linalg.inv(self.matrix.value)
-        return TPCorr(v2ref=self.v2ref.value, v3ref=self.v3ref.value,
-                      roll=self.roll.value, matrix=imatrix, shift=ishift)
-
-    @classmethod
-    def combine(cls, t2, t1):
-        """
-        Combine transformation ``t2`` with another transformation (``t1``)
-        *previously applied* to the coordinates. That is,
-        transformation ``t2`` is assumed to *follow* (=applied after) the
-        transformation provided by the argument ``t1``.
-
-        """
-        if not isinstance(t1, TPCorr):
-            raise IncompatibleCorrections(  # pragma: no cover
-                "Tangent plane correction 't1' is not a TPCorr instance."
-            )
-
-        if not isinstance(t2, TPCorr):
-            raise IncompatibleCorrections(  # pragma: no cover
-                "Tangent plane correction 't2' is not a TPCorr instance."
-            )
-
-        eps_v2 = 10.0 * np.finfo(t2.v2ref.value).eps
-        eps_v3 = 10.0 * np.finfo(t2.v3ref.value).eps
-        eps_roll = 10.0 * np.finfo(t2.roll.value).eps
-        if not (np.isclose(t2.v2ref.value, t1.v2ref.value, rtol=eps_v2) and
-                np.isclose(t2.v3ref.value, t1.v3ref.value, rtol=eps_v3) and
-                np.isclose(t2.roll.value, t1.roll.value, rtol=eps_roll)):
-            raise IncompatibleCorrections(  # pragma: no cover
-                "Only combining of correction transformations within the same "
-                "tangent plane is supported."
-            )
-
-        t1m = t1.matrix.value
-        it1m = np.linalg.inv(t1m)
-        shift = t1.shift.value + np.dot(it1m, t2.shift.value)
-        matrix = np.dot(t2.matrix.value, t1m)
-
-        name = t1.name if t2.name is None else t2.name
-
-        return cls(v2ref=t2.v2ref.value, v3ref=t2.v3ref.value,
-                   roll=t2.roll.value, matrix=matrix, shift=shift, name=name)

--- a/tweakwcs/tests/test_jwst_utils.py
+++ b/tweakwcs/tests/test_jwst_utils.py
@@ -5,22 +5,10 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 from itertools import groupby
-import sys
 
 import pytest
 
 from tweakwcs.utils.jwst_utils import assign_jwst_tweakwcs_groups
-
-
-def test_jwst_import_failed():
-    restore_modules = {}
-    with pytest.raises(ImportError):
-        for k in list(sys.modules.keys()):
-            if k.startswith(('jwst')):
-                restore_modules[k] = sys.modules[k]
-                sys.modules[k] = None
-        assign_jwst_tweakwcs_groups([])
-    sys.modules.update(restore_modules)
 
 
 @pytest.fixture(scope='function')
@@ -95,6 +83,4 @@ def test_assign_jwst_tweakwcs_groups(data_model_list, monkeypatch):
     assign_jwst_tweakwcs_groups(list(models.keys()))
 
     gids = sorted([model.meta.tweakwcs_group_id for model in data_model_list])
-    print(gids)
     assert sorted([len(list(g)) for k, g in groupby(gids)]) == [1, 2, 3]
-    # assert False

--- a/tweakwcs/tests/test_wcsutils.py
+++ b/tweakwcs/tests/test_wcsutils.py
@@ -5,11 +5,26 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import pytest
+from distutils.version import LooseVersion
+
 import numpy as np
 
 from tweakwcs import wcsutils
+import gwcs
+if LooseVersion(gwcs.__version__) > '0.12.0':
+    from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
+    _NO_JWST_SUPPORT = False
+    _S2C = SphericalToCartesian(name='s2c')
+    _C2S = CartesianToSpherical(name='c2s')
+else:
+    _NO_JWST_SUPPORT = True
 
 
+# _S2C = SphericalToCartesian(name='s2c')
+# _C2S = CartesianToSpherical(name='c2s')
+
+
+@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 @pytest.mark.parametrize('x,y,z', [
     (1, 0, 0),
     (0, 1, 0),
@@ -20,33 +35,29 @@ from tweakwcs import wcsutils
 ])
 def test_cartesian_spherical_cartesian_roundtrip_special(x, y, z):
     feps = 100 * np.finfo(np.float64).eps
-    xyz = wcsutils.spherical_to_cartesian(
-        *wcsutils.cartesian_to_spherical(x, y, z)
-    )
+    xyz = _S2C(*_C2S(x, y, z))
     assert np.allclose((x, y, z), xyz, rtol=0, atol=feps)
 
 
+@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_cartesian_spherical_cartesian_roundtrip_rand():
     feps = 100 * np.finfo(np.float64).eps
     xyz = np.random.random((100, 3))
     xyz /= np.linalg.norm(xyz, axis=1)[:, np.newaxis]
     x, y, z = xyz.T
-    rx, ry, rz = wcsutils.spherical_to_cartesian(
-        *wcsutils.cartesian_to_spherical(x, y, z)
-    )
+    rx, ry, rz = _S2C(*_C2S(x, y, z))
     assert np.allclose(rx, x, rtol=0, atol=feps)
     assert np.allclose(ry, y, rtol=0, atol=feps)
     assert np.allclose(rz, z, rtol=0, atol=feps)
 
 
+@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_spherical_cartesian_spherical_roundtrip_ugrid():
-    feps = 100 * np.finfo(np.float64).eps
-    angles = np.linspace(0, 360, 13) - 180
+    feps = 1000 * np.finfo(np.float64).eps
+    angles = np.linspace(0, 360, 13)
     alpha0 = np.repeat(angles, angles.size)
-    delta0 = np.tile(angles / 2, angles.size)
-    alpha, delta = wcsutils.cartesian_to_spherical(
-        *wcsutils.spherical_to_cartesian(alpha0, delta0)
-    )
+    delta0 = np.tile(angles / 2 - 90, angles.size)
+    alpha, delta = _C2S(*_S2C(alpha0, delta0))
     assert np.allclose(alpha, alpha0, rtol=0, atol=feps)
     assert np.allclose(delta, delta0, rtol=0, atol=feps)
 

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -8,21 +8,20 @@ of ``WCS``.
 :License: :doc:`../LICENSE`
 
 """
-# STDLIB
 import logging
 from copy import deepcopy
 from abc import ABC, abstractmethod
+from distutils.version import LooseVersion
 
-# THIRD-PARTY
 import numpy as np
 import gwcs
 
-try:
-    from jwst.transforms.tpcorr import TPCorr  # pylint: disable=W0611
-except ImportError:
-    TPCorr = None
+from astropy.modeling import CompoundModel
+from astropy.modeling.models import (
+    AffineTransformation2D, Scale, Identity, Mapping, Const1D,
+    RotationSequence3D
+)
 
-# LOCAL
 from .linalg import inv
 from . import __version__  # noqa: F401
 
@@ -32,6 +31,21 @@ __all__ = ['TPWCS', 'JWSTgWCS', 'FITSWCS']
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+
+_RAD2ARCSEC = 3600.0 * np.rad2deg(1.0)
+_ARCSEC2RAD = 1.0 / _RAD2ARCSEC
+
+
+if LooseVersion(gwcs.__version__) > '0.12.0':
+    from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
+    _JWST_SUPPORT = True
+else:
+    _JWST_SUPPORT = False
+    log.warning(
+        "JWST support requires gwcs version > 12.1. "
+        "To pip install minimal required version, do the following:\n"
+        "pip install git+https://github.com/spacetelescope/gwcs@ad951ec"
+    )
 
 
 class TPWCS(ABC):
@@ -220,301 +234,6 @@ class TPWCS(ABC):
 
         """
         return None
-
-
-class JWSTgWCS(TPWCS):
-    """ A class for holding ``JWST`` ``gWCS`` information and for managing
-    tangent-plane corrections.
-
-    """
-
-    def __init__(self, wcs, wcsinfo, meta=None):
-        """
-        Parameters
-        ----------
-        wcs : GWCS
-            A `GWCS` object.
-
-        wcsinfo : dict
-            A dictionary containing reference angles of ``JWST`` instrument
-            provided in the ``wcsinfo`` property of ``JWST`` meta data.
-
-            This dictionary **must contain** the following keys and values:
-
-
-            'v2_ref' : float
-                V2 position of the reference point in arc seconds.
-
-            'v3_ref' : float
-                V3 position of the reference point in arc seconds.
-
-            'roll_ref' : float
-                Roll angle in degrees.
-
-        meta : dict, None, optional
-            Dictionary that will be merged to the object's ``meta`` fields.
-
-        """
-        if TPCorr is None:
-            raise ImportError("The 'jwst' package must be installed in order "
-                              "to correct JWST WCS.")
-
-        valid, message = self._check_wcs_structure(wcs)
-        if not valid:
-            raise ValueError("Unsupported WCS structure: {}".format(message))
-
-        super().__init__(wcs=wcs, meta=meta)
-
-        v2_ref = wcsinfo['v2_ref']
-        v3_ref = wcsinfo['v3_ref']
-        roll_ref = wcsinfo['roll_ref']
-
-        self._wcsinfo = {'v2_ref': v2_ref, 'v3_ref': v3_ref,
-                         'roll_ref': roll_ref}
-
-        # perform additional check that if tangent plane correction is already
-        # present in the WCS pipeline, it is of TPCorr class and that
-        # its parameters are consistent with reference angles:
-        frms = wcs.available_frames
-        if 'v2v3corr' in frms:
-            self._v23name = 'v2v3corr'
-            self._tpcorr = deepcopy(
-                wcs.pipeline[frms.index('v2v3corr') - 1][1]
-            )
-            self._default_tpcorr = None
-            if not isinstance(self._tpcorr, TPCorr):
-                raise ValueError("Unsupported tangent-plance correction type.")
-
-            # check that transformation parameters are consistent with
-            # reference angles:
-            v2ref = self._tpcorr.v2ref.value
-            v3ref = self._tpcorr.v3ref.value
-            roll = self._tpcorr.roll.value
-            eps_v2 = 10.0 * np.finfo(v2_ref).eps
-            eps_v3 = 10.0 * np.finfo(v3_ref).eps
-            eps_roll = 10.0 * np.finfo(roll_ref).eps
-            if not (np.isclose(v2_ref, v2ref * 3600.0, rtol=eps_v2) and
-                    np.isclose(v3_ref, v3ref * 3600.0, rtol=eps_v3) and
-                    np.isclose(roll_ref, roll, rtol=eps_roll)):
-                raise ValueError(
-                    "WCS/TPCorr parameters 'v2ref', 'v3ref', and/or 'roll' "
-                    "differ from the corresponding reference values."
-                )
-
-        else:
-            self._v23name = 'v2v3'
-            self._tpcorr = None
-            self._default_tpcorr = TPCorr(
-                v2ref=v2_ref / 3600.0, v3ref=v3_ref / 3600.0, roll=roll_ref,
-                name='tangent-plane linear correction'
-            )
-
-        self._update_transformations()
-
-    def _update_transformations(self):
-        # define transformations from detector/world coordinates to
-        # the tangent plane:
-        detname = self._wcs.pipeline[0][0].name
-        worldname = self._wcs.pipeline[-1][0].name
-
-        self._world_to_v23 = self._wcs.get_transform(worldname, self._v23name)
-        self._v23_to_world = self._wcs.get_transform(self._v23name, worldname)
-        self._det_to_v23 = self._wcs.get_transform(detname, self._v23name)
-        self._v23_to_det = self._wcs.get_transform(self._v23name, detname)
-
-        self._det_to_world = self._wcs.__call__
-        self._world_to_det = self._wcs.invert
-
-    @property
-    def ref_angles(self):
-        """ Return a ``wcsinfo``-like dictionary of main WCS parameters. """
-        return {k: v for k, v in self._wcsinfo.items()}
-
-    def set_correction(self, matrix=[[1, 0], [0, 1]], shift=[0, 0], meta=None,
-                       **kwargs):
-        """
-        Sets a tangent-plane correction of the GWCS object according to
-        the provided liniar parameters. In addition, this function updates
-        the ``meta`` attribute of the `JWSTgWCS` object with the values
-        of keyword arguments except for the argument ``meta`` which is
-        *merged* with the *attribute* ``meta``.
-
-        Parameters
-        ----------
-        matrix : list, numpy.ndarray
-            A ``2x2`` array or list of lists coefficients representing scale,
-            rotation, and/or skew transformations.
-
-        shift : list, numpy.ndarray
-            A list of two coordinate shifts to be applied to coordinates
-            *before* ``matrix`` transformations are applied.
-
-        meta : dict, None, optional
-            Dictionary that will be merged to the object's ``meta`` fields.
-
-        **kwargs : optional parameters
-            Optional parameters for the WCS corrector. `JWSTgWCS` ignores these
-            arguments (except for storing them in the ``meta`` attribute).
-
-        """
-        frms = self._wcs.available_frames
-
-        # if original WCS did not have tangent-plane corrections, create
-        # new correction and add it to the WCs pipeline:
-        if self._tpcorr is None:
-            self._tpcorr = TPCorr(
-                v2ref=self._wcsinfo['v2_ref'] / 3600.0,
-                v3ref=self._wcsinfo['v3_ref'] / 3600.0,
-                roll=self._wcsinfo['roll_ref'],
-                matrix=matrix,
-                shift=shift,
-                name='tangent-plane linear correction'
-            )
-            idx_v2v3 = frms.index(self._v23name)
-            pipeline = deepcopy(self._wcs.pipeline)
-            pf, pt = pipeline[idx_v2v3]
-            pipeline[idx_v2v3] = (pf, deepcopy(self._tpcorr))
-            frm_v2v3corr = deepcopy(pf)
-            frm_v2v3corr.name = 'v2v3corr'
-            pipeline.insert(idx_v2v3 + 1, (frm_v2v3corr, pt))
-            self._wcs = gwcs.WCS(pipeline, name=self._owcs.name)
-            self._v23name = 'v2v3corr'
-
-        else:
-            # combine old and new corrections into a single one and replace
-            # old transformation with the combined correction transformation:
-            tpcorr2 = self._tpcorr.__class__(
-                v2ref=self._tpcorr.v2ref, v3ref=self._tpcorr.v3ref,
-                roll=self._tpcorr.roll, matrix=matrix, shift=shift,
-                name='tangent-plane linear correction'
-            )
-
-            self._tpcorr = tpcorr2.combine(tpcorr2, self._tpcorr)
-
-            idx_v2v3 = frms.index(self._v23name)
-            pipeline = deepcopy(self._wcs.pipeline)
-            pipeline[idx_v2v3 - 1] = (pipeline[idx_v2v3 - 1][0],
-                                      deepcopy(self._tpcorr))
-            self._wcs = gwcs.WCS(pipeline, name=self._owcs.name)
-
-        # reset definitions of the transformations from detector/world
-        # coordinates to the tangent plane:
-        self._update_transformations()
-
-        # save linear transformation info to the meta attribute:
-        super().set_correction(matrix=matrix, shift=shift, meta=meta, **kwargs)
-
-    def _check_wcs_structure(self, wcs):
-        if wcs is None or wcs.pipeline is None:
-            return False, "Either WCS or its pipeline is None."
-
-        frms = wcs.available_frames
-        nframes = len(frms)
-
-        if nframes < 3:
-            return False, "There are fewer than 3 frames in the WCS pipeline."
-
-        if frms.count(frms[0]) > 1 or frms.count(frms[-1]) > 1:
-            return (False, "First and last frames in the WCS pipeline must "
-                    "be unique.")
-
-        if frms.count('v2v3') != 1:
-            return (False, "Only one 'v2v3' frame is allowed in the WCS "
-                    "pipeline.")
-
-        idx_v2v3 = frms.index('v2v3')
-        if idx_v2v3 == 0 or idx_v2v3 == (nframes - 1):
-            return (False, "'v2v3' frame cannot be first or last in the WCS "
-                    "pipeline.")
-
-        nv2v3corr = frms.count('v2v3corr')
-        if nv2v3corr == 0:
-            return True, ''
-        elif nv2v3corr > 1:
-            return (False, "Only one 'v2v3corr' correction frame is allowed "
-                    "in the WCS pipeline.")
-
-        idx_v2v3corr = frms.index('v2v3corr')
-        if idx_v2v3corr != (idx_v2v3 + 1) or idx_v2v3corr == (nframes - 1):
-            return (False, "'v2v3corr' frame is not in the correct position "
-                    "in the WCS pipeline.")
-
-        return True, ''
-
-    def det_to_world(self, x, y):
-        """
-        Convert pixel coordinates to sky coordinates using full
-        (i.e., including distortions) transformations.
-
-        """
-        ra, dec = self._det_to_world(x, y)
-        return ra, dec
-
-    def world_to_det(self, ra, dec):
-        """
-        Convert sky coordinates to image's pixel coordinates using full
-        (i.e., including distortions) transformations.
-
-        """
-        x, y = self._world_to_det(ra, dec)
-        return x, y
-
-    def det_to_tanp(self, x, y):
-        """
-        Convert detector (pixel) coordinates to tangent plane coordinates.
-
-        """
-        tpc = self._default_tpcorr if self._tpcorr is None else self._tpcorr
-        v2, v3 = self._det_to_v23(x, y)
-        x, y = tpc.v2v3_to_tanp(v2, v3)
-        return x, y
-
-    def tanp_to_det(self, x, y):
-        """
-        Convert tangent plane coordinates to detector (pixel) coordinates.
-
-        """
-        tpc = self._default_tpcorr if self._tpcorr is None else self._tpcorr
-        v2, v3 = tpc.tanp_to_v2v3(x, y)
-        x, y = self._v23_to_det(v2, v3)
-        return x, y
-
-    def world_to_tanp(self, ra, dec):
-        """
-        Convert tangent plane coordinates to detector (pixel) coordinates.
-
-        """
-        tpc = self._default_tpcorr if self._tpcorr is None else self._tpcorr
-        v2, v3 = self._world_to_v23(ra, dec)
-        x, y = tpc.v2v3_to_tanp(v2, v3)
-        return x, y
-
-    def tanp_to_world(self, x, y):
-        """ Convert tangent plane coordinates to world coordinates. """
-        tpc = self._default_tpcorr if self._tpcorr is None else self._tpcorr
-        v2, v3 = tpc.tanp_to_v2v3(x, y)
-        ra, dec = self._v23_to_world(v2, v3)
-        return ra, dec
-
-    @property
-    def bounding_box(self):
-        """
-        Get the bounding box (if any) of the underlying image for which
-        the original WCS is defined.
-
-        """
-        if self._owcs.pixel_bounds is None:
-            if self._owcs.pixel_shape is not None:
-                nx, ny = self._owcs.pixel_shape
-            elif self._owcs.array_shape is not None:
-                ny, nx = self._owcs.array_shape
-            else:
-                return None
-
-            return ((-0.5, nx - 0.5), (-0.5, ny - 0.5))
-
-        else:
-            return self._owcs.pixel_bounds
 
 
 class FITSWCS(TPWCS):
@@ -775,3 +494,436 @@ def _linearize(wcsim, wcsima, wcsref, imcrpix, f, shift, hx=1.0, hy=1.0):
     u2 = ((p[5] - p[8]) + 8 * (p[7] - p[6])) / (6 * hy)
 
     return (np.asarray([u1, u2]).T, p[0])
+
+
+def _get_submodel(model, name):
+    """ Return the first occurence of a sub-model. Search is performed by
+        model name.
+    """
+    if not isinstance(model, CompoundModel):
+        return model if model.name == name else None
+
+    for m in model.traverse_postorder():
+        if m.name == name:
+            return m
+
+    return None
+
+
+class JWSTgWCS(TPWCS):
+    """ A class for holding ``JWST`` ``gWCS`` information and for managing
+    tangent-plane corrections.
+
+    """
+    def __init__(self, wcs, wcsinfo, meta=None):
+        """
+        Parameters
+        ----------
+        wcs : GWCS
+            A `GWCS` object.
+
+        wcsinfo : dict
+            A dictionary containing reference angles of ``JWST`` instrument
+            provided in the ``wcsinfo`` property of ``JWST`` meta data.
+
+            This dictionary **must contain** the following keys and values:
+
+
+            'v2_ref' : float
+                V2 position of the reference point in arc seconds.
+
+            'v3_ref' : float
+                V3 position of the reference point in arc seconds.
+
+            'roll_ref' : float
+                Roll angle in degrees.
+
+        meta : dict, None, optional
+            Dictionary that will be merged to the object's ``meta`` fields.
+
+        """
+        if not _JWST_SUPPORT:
+            raise NotImplementedError(
+                "JWST support requires gwcs version > 12.1. "
+                "To pip install minimal required version, do the following:\n"
+                "pip install git+https://github.com/spacetelescope/gwcs@ad951ec"
+            )
+
+        valid, message = self._check_wcs_structure(wcs)
+        if not valid:
+            raise ValueError("Unsupported WCS structure: {}".format(message))
+
+        super().__init__(wcs=wcs, meta=meta)
+
+        v2_ref = wcsinfo['v2_ref']
+        v3_ref = wcsinfo['v3_ref']
+        roll_ref = wcsinfo['roll_ref']
+
+        self._wcsinfo = {'v2_ref': v2_ref, 'v3_ref': v3_ref,
+                         'roll_ref': roll_ref}
+
+        # perform additional check that if tangent plane correction is already
+        # present in the WCS pipeline, it is of TPCorr class and that
+        # its parameters are consistent with reference angles:
+        frms = wcs.available_frames
+        if 'v2v3corr' in frms:
+            self._v23name = 'v2v3corr'
+            self._tpcorr = deepcopy(
+                wcs.pipeline[frms.index('v2v3corr') - 1][1]
+            )
+            self._default_tpcorr = None
+            if not JWSTgWCS._check_tpcorr_structure(self._tpcorr):
+                raise ValueError("Unsupported tangent-plance correction type.")
+
+            # check that transformation parameters are consistent with
+            # reference angles:
+            v2ref, v3ref, roll = self._tpcorr['det_to_optic_axis'].angles.value
+
+            eps_v2 = 10.0 * np.finfo(v2_ref).eps
+            eps_v3 = 10.0 * np.finfo(v3_ref).eps
+            eps_roll = 10.0 * np.finfo(roll_ref).eps
+            if not (np.isclose(v2_ref, v2ref * 3600.0, rtol=eps_v2) and
+                    np.isclose(v3_ref, -v3ref * 3600.0, rtol=eps_v3) and
+                    np.isclose(roll_ref, roll, rtol=eps_roll)):
+                raise ValueError(
+                    "WCS/TPCorr parameters 'v2ref', 'v3ref', and/or 'roll' "
+                    "differ from the corresponding reference values."
+                )
+            self._partial_tpcorr = JWSTgWCS._v2v3_to_tpcorr_from_full(
+                self._tpcorr
+            )
+
+        else:
+            self._v23name = 'v2v3'
+            self._tpcorr = None
+            self._default_tpcorr = JWSTgWCS._tpcorr_init(
+                v2_ref=v2_ref / 3600.0,
+                v3_ref=v3_ref / 3600.0,
+                roll_ref=roll_ref
+            )
+            self._partial_tpcorr = JWSTgWCS._v2v3_to_tpcorr_from_full(
+                self._default_tpcorr
+            )
+
+        self._update_transformations()
+
+    @staticmethod
+    def _check_tpcorr_structure(tpcorr):
+        # implement a more sophisticated check later
+        if tpcorr.name != 'jwst tangent-plane linear correction. v1':
+            return False
+        return True
+
+    def _update_transformations(self):
+        # define transformations from detector/world coordinates to
+        # the tangent plane:
+        detname = self._wcs.pipeline[0][0].name
+        worldname = self._wcs.pipeline[-1][0].name
+
+        self._world_to_v23 = self._wcs.get_transform(worldname, self._v23name)
+        self._v23_to_world = self._wcs.get_transform(self._v23name, worldname)
+        self._det_to_v23 = self._wcs.get_transform(detname, self._v23name)
+        self._v23_to_det = self._wcs.get_transform(self._v23name, detname)
+
+        self._det_to_world = self._wcs.__call__
+        self._world_to_det = self._wcs.invert
+
+    @staticmethod
+    def _tpcorr_combine_affines(tpcorr, matrix, shift):
+        AffineTransformation2D(matrix, shift)  # check input parameters are OK
+        m = np.dot(matrix, tpcorr['tp_affine'].matrix.value)
+        t = np.dot(matrix, tpcorr['tp_affine'].translation.value) + shift
+        tpcorr['tp_affine'].matrix = m
+        tpcorr['tp_affine'].translation = t
+
+    @staticmethod
+    def _tpcorr_init(v2_ref, v3_ref, roll_ref):
+        s2c = SphericalToCartesian(name='s2c')
+        c2s = CartesianToSpherical(name='c2s')
+
+        unit_conv = Scale(1.0 / 3600.0, name='arcsec_to_deg_1D')
+        unit_conv = unit_conv & unit_conv
+        unit_conv.name = 'arcsec_to_deg_2D'
+
+        unit_conv_inv = Scale(3600.0, name='deg_to_arcsec_1D')
+        unit_conv_inv = unit_conv_inv & unit_conv_inv
+        unit_conv_inv.name = 'deg_to_arcsec_2D'
+
+        affine = AffineTransformation2D(name='tp_affine')
+        affine_inv = AffineTransformation2D(name='tp_affine_inv')
+
+        rot = RotationSequence3D(
+            [v2_ref, -v3_ref, roll_ref],
+            'zyx',
+            name='det_to_optic_axis'
+        )
+        rot_inv = rot.inverse
+        rot_inv.name = 'optic_axis_to_det'
+
+        # projection submodels:
+        c2tan = ((Mapping((0, 1, 2), name='xyz') /
+                  Mapping((0, 0, 0), n_inputs=3, name='xxx')) |
+                 Mapping((1, 2), name='xtyt'))
+        c2tan.name = 'cartesian 3D to TAN'
+        tan2c = (Mapping((0, 0, 1), n_inputs=2, name='xtyt2xyz') |
+                 (Const1D(1, name='one') & Identity(2, name='I(2D)')))
+        tan2c.name = 'TAN to cartesian 3D'
+
+        total_corr = (
+            unit_conv | s2c | rot | c2tan | affine |
+            tan2c | rot_inv | c2s | unit_conv_inv
+        )
+        total_corr.name = 'jwst tangent-plane linear correction. v1'
+
+        inv_total_corr = (
+            unit_conv | s2c | rot | c2tan | affine_inv |
+            tan2c | rot_inv | c2s | unit_conv_inv
+        )
+        inv_total_corr.name = 'inverse jwst tangent-plane linear correction. v1'
+
+        inv_total_corr.inverse = total_corr
+        total_corr.inverse = inv_total_corr
+
+        return total_corr
+
+    @staticmethod
+    def _v2v3_to_tpcorr_from_full(tpcorr):
+        s2c = tpcorr['s2c']
+        c2s = tpcorr['c2s']
+        unit_conv = _get_submodel(tpcorr, 'arcsec_to_deg_2D')
+        unit_conv_inv = _get_submodel(tpcorr, 'deg_to_arcsec_2D')
+        affine = tpcorr['tp_affine']
+        affine_inv = affine.inverse
+        affine_inv.name = 'tp_affine_inv'
+
+        rot = tpcorr['det_to_optic_axis']
+        rot_inv = rot.inverse
+        rot_inv.name = 'optic_axis_to_det'
+
+        c2tan = _get_submodel(tpcorr, 'cartesian 3D to TAN')
+        tan2c = _get_submodel(tpcorr, 'TAN to cartesian 3D')
+
+        v2v3_to_tpcorr = unit_conv | s2c | rot | c2tan | affine
+        v2v3_to_tpcorr.name = 'jwst_v2v3_to_tpcorr'
+
+        tpcorr_to_v2v3 = affine_inv | tan2c | rot_inv | c2s | unit_conv_inv
+        tpcorr_to_v2v3.name = 'jwst_tpcorr_to_v2v3'
+
+        v2v3_to_tpcorr.inverse = tpcorr_to_v2v3
+        tpcorr_to_v2v3.inverse = v2v3_to_tpcorr
+
+        return v2v3_to_tpcorr
+
+    @property
+    def ref_angles(self):
+        """ Return a ``wcsinfo``-like dictionary of main WCS parameters. """
+        return {k: v for k, v in self._wcsinfo.items()}
+
+    def set_correction(self, matrix=[[1, 0], [0, 1]], shift=[0, 0], meta=None,
+                       **kwargs):
+        """
+        Sets a tangent-plane correction of the GWCS object according to
+        the provided liniar parameters. In addition, this function updates
+        the ``meta`` attribute of the `JWSTgWCS` object with the values
+        of keyword arguments except for the argument ``meta`` which is
+        *merged* with the *attribute* ``meta``.
+
+        Parameters
+        ----------
+        matrix : list, numpy.ndarray
+            A ``2x2`` array or list of lists coefficients representing scale,
+            rotation, and/or skew transformations.
+
+        shift : list, numpy.ndarray
+            A list of two coordinate shifts to be applied to coordinates
+            *before* ``matrix`` transformations are applied.
+
+        meta : dict, None, optional
+            Dictionary that will be merged to the object's ``meta`` fields.
+
+        **kwargs : optional parameters
+            Optional parameters for the WCS corrector. `JWSTgWCS` ignores these
+            arguments (except for storing them in the ``meta`` attribute).
+
+        """
+        frms = self._wcs.available_frames
+
+        # if original WCS did not have tangent-plane corrections, create
+        # new correction and add it to the WCs pipeline:
+        if self._tpcorr is None:
+            self._tpcorr = JWSTgWCS._tpcorr_init(
+                v2_ref=self._wcsinfo['v2_ref'] / 3600.0,
+                v3_ref=self._wcsinfo['v3_ref'] / 3600.0,
+                roll_ref=self._wcsinfo['roll_ref']
+            )
+
+            JWSTgWCS._tpcorr_combine_affines(
+                self._tpcorr,
+                matrix,
+                -_ARCSEC2RAD * np.dot(matrix, shift)
+            )
+
+            self._partial_tpcorr = JWSTgWCS._v2v3_to_tpcorr_from_full(self._tpcorr)
+
+            idx_v2v3 = frms.index(self._v23name)
+            pipeline = deepcopy(self._wcs.pipeline)
+            pf, pt = pipeline[idx_v2v3]
+            pipeline[idx_v2v3] = (pf, deepcopy(self._tpcorr))
+            frm_v2v3corr = deepcopy(pf)
+            frm_v2v3corr.name = 'v2v3corr'
+            pipeline.insert(idx_v2v3 + 1, (frm_v2v3corr, pt))
+            self._wcs = gwcs.WCS(pipeline, name=self._owcs.name)
+            self._v23name = 'v2v3corr'
+
+        else:
+            # combine old and new corrections into a single one and replace
+            # old transformation with the combined correction transformation:
+            v2ref, v3ref, roll = self._tpcorr['det_to_optic_axis'].angles.value
+
+            tpcorr2 = JWSTgWCS._tpcorr_init(
+                v2_ref=v2ref,
+                v3_ref=v3ref,
+                roll_ref=roll
+            )
+
+            JWSTgWCS._tpcorr_combine_affines(
+                tpcorr2,
+                matrix,
+                -_ARCSEC2RAD * np.dot(matrix, shift)
+            )
+
+            JWSTgWCS._tpcorr_combine_affines(
+                tpcorr2,
+                self._tpcorr['tp_affine'].matrix.value,
+                self._tpcorr['tp_affine'].translation.value
+            )
+
+            self._tpcorr = tpcorr2
+            self._partial_tpcorr = JWSTgWCS._v2v3_to_tpcorr_from_full(tpcorr2)
+
+            idx_v2v3 = frms.index(self._v23name)
+            pipeline = deepcopy(self._wcs.pipeline)
+            pipeline[idx_v2v3 - 1] = (pipeline[idx_v2v3 - 1][0],
+                                      deepcopy(self._tpcorr))
+            self._wcs = gwcs.WCS(pipeline, name=self._owcs.name)
+
+        # reset definitions of the transformations from detector/world
+        # coordinates to the tangent plane:
+        self._update_transformations()
+
+        # save linear transformation info to the meta attribute:
+        super().set_correction(matrix=matrix, shift=shift, meta=meta, **kwargs)
+
+    def _check_wcs_structure(self, wcs):
+        if wcs is None or wcs.pipeline is None:
+            return False, "Either WCS or its pipeline is None."
+
+        frms = wcs.available_frames
+        nframes = len(frms)
+
+        if nframes < 3:
+            return False, "There are fewer than 3 frames in the WCS pipeline."
+
+        if frms.count(frms[0]) > 1 or frms.count(frms[-1]) > 1:
+            return (False, "First and last frames in the WCS pipeline must "
+                    "be unique.")
+
+        if frms.count('v2v3') != 1:
+            return (False, "Only one 'v2v3' frame is allowed in the WCS "
+                    "pipeline.")
+
+        idx_v2v3 = frms.index('v2v3')
+        if idx_v2v3 == 0 or idx_v2v3 == (nframes - 1):
+            return (False, "'v2v3' frame cannot be first or last in the WCS "
+                    "pipeline.")
+
+        nv2v3corr = frms.count('v2v3corr')
+        if nv2v3corr == 0:
+            return True, ''
+        elif nv2v3corr > 1:
+            return (False, "Only one 'v2v3corr' correction frame is allowed "
+                    "in the WCS pipeline.")
+
+        idx_v2v3corr = frms.index('v2v3corr')
+        if idx_v2v3corr != (idx_v2v3 + 1) or idx_v2v3corr == (nframes - 1):
+            return (False, "'v2v3corr' frame is not in the correct position "
+                    "in the WCS pipeline.")
+
+        return True, ''
+
+    def det_to_world(self, x, y):
+        """
+        Convert pixel coordinates to sky coordinates using full
+        (i.e., including distortions) transformations.
+
+        """
+        ra, dec = self._det_to_world(x, y)
+        return ra, dec
+
+    def world_to_det(self, ra, dec):
+        """
+        Convert sky coordinates to image's pixel coordinates using full
+        (i.e., including distortions) transformations.
+
+        """
+        x, y = self._world_to_det(ra, dec)
+        return x, y
+
+    def det_to_tanp(self, x, y):
+        """
+        Convert detector (pixel) coordinates to tangent plane coordinates.
+
+        """
+        v2, v3 = self._det_to_v23(x, y)
+        x, y = self._partial_tpcorr(v2, v3)
+        return _RAD2ARCSEC * x, _RAD2ARCSEC * y
+
+    def tanp_to_det(self, x, y):
+        """
+        Convert tangent plane coordinates to detector (pixel) coordinates.
+
+        """
+        v2, v3 = self._partial_tpcorr.inverse(
+            _ARCSEC2RAD * np.asanyarray(x),
+            _ARCSEC2RAD * np.asanyarray(y)
+        )
+        x, y = self._v23_to_det(v2, v3)
+        return x, y
+
+    def world_to_tanp(self, ra, dec):
+        """
+        Convert tangent plane coordinates to detector (pixel) coordinates.
+
+        """
+        v2, v3 = self._world_to_v23(ra, dec)
+        x, y = self._partial_tpcorr(v2, v3)
+        return _RAD2ARCSEC * x, _RAD2ARCSEC * y
+
+    def tanp_to_world(self, x, y):
+        """ Convert tangent plane coordinates to world coordinates. """
+        v2, v3 = self._partial_tpcorr.inverse(
+            _ARCSEC2RAD * np.asanyarray(x),
+            _ARCSEC2RAD * np.asanyarray(y)
+        )
+        ra, dec = self._v23_to_world(v2, v3)
+        return ra, dec
+
+    @property
+    def bounding_box(self):
+        """
+        Get the bounding box (if any) of the underlying image for which
+        the original WCS is defined.
+
+        """
+        if self._owcs.pixel_bounds is None:
+            if self._owcs.pixel_shape is not None:
+                nx, ny = self._owcs.pixel_shape
+            elif self._owcs.array_shape is not None:
+                ny, nx = self._owcs.array_shape
+            else:
+                return None
+
+            return ((-0.5, nx - 0.5), (-0.5, ny - 0.5))
+
+        else:
+            return self._owcs.pixel_bounds

--- a/tweakwcs/wcsutils.py
+++ b/tweakwcs/wcsutils.py
@@ -17,7 +17,7 @@ import numpy as np
 from . import __version__  # noqa: F401
 
 
-__all__ = ['cartesian_to_spherical', 'spherical_to_cartesian', 'planar_rot_3d']
+__all__ = ['planar_rot_3d']
 
 __author__ = 'Mihai Cara'
 
@@ -37,21 +37,3 @@ def planar_rot_3d(angle, axis):
                      dtype=np.float)
     mat_2d = np.array([[cs, sn], [-sn, cs]], dtype=np.float)
     return np.insert(np.insert(mat_2d, axis, [0.0, 0.0], 1), axis, axisv, 0)
-
-
-def cartesian_to_spherical(x, y, z):
-    """ Convert cartesian coordinates to spherical coordinates (in deg). """
-    h = np.hypot(x, y)
-    alpha = np.rad2deg(np.arctan2(y, x))
-    delta = np.rad2deg(np.arctan2(z, h))
-    return alpha, delta
-
-
-def spherical_to_cartesian(alpha, delta):
-    """ Convert spherical coordinates (in deg) to cartesian. """
-    alpha = np.deg2rad(alpha)
-    delta = np.deg2rad(delta)
-    x = np.cos(alpha) * np.cos(delta)
-    y = np.cos(delta) * np.sin(alpha)
-    z = np.sin(delta)
-    return x, y, z


### PR DESCRIPTION
This PR replaces `TPCorr` model (from the `jwst` pipeline) with standard models from `astropy` and `gwcs`. Therefore, `jwst` package is no longer needed to be able to align JWST images (kind of... `DataModel` is still needed...)