### PR TITLE
Temp disable inv of inv and fix angle wrapping

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Release Notes
 - Re-designed the ``JWSTgWCS`` corrector class to rely exclusively on
   basic models available in ``astropy`` and ``gwcs`` instead of the ``TPCorr``
   class provided by the ``jwst`` pipeline. This eliminates the need to install
-  the ``jwst`` pipeline in order to align ``JWST`` images. [#96]
+  the ``jwst`` pipeline in order to align ``JWST`` images. [#96, #98]
 
 0.5.3 (15-November-2019)
 ========================

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -638,8 +638,8 @@ class JWSTgWCS(TPWCS):
 
     @staticmethod
     def _tpcorr_init(v2_ref, v3_ref, roll_ref):
-        s2c = SphericalToCartesian(name='s2c')
-        c2s = CartesianToSpherical(name='c2s')
+        s2c = SphericalToCartesian(name='s2c', wrap_phi_at=180)
+        c2s = CartesianToSpherical(name='c2s', wrap_phi_at=180)
 
         unit_conv = Scale(1.0 / 3600.0, name='arcsec_to_deg_1D')
         unit_conv = unit_conv & unit_conv
@@ -681,7 +681,12 @@ class JWSTgWCS(TPWCS):
         )
         inv_total_corr.name = 'inverse jwst tangent-plane linear correction. v1'
 
-        inv_total_corr.inverse = total_corr
+        # TODO
+        # re-enable circular inverse definitions once
+        # https://github.com/spacetelescope/asdf/issues/744 or
+        # https://github.com/spacetelescope/asdf/issues/745 are resolved.
+        #
+        # inv_total_corr.inverse = total_corr
         total_corr.inverse = inv_total_corr
 
         return total_corr


### PR DESCRIPTION
This PR temporarily disables circular definition of inverses of the tangent-plane correction models due to issues in #97. This should be re-enabled once https://github.com/spacetelescope/asdf/issues/744 and https://github.com/spacetelescope/asdf/issues/745 are taken care of.

This PR also corrects the angle wrap value used in cartesian<->spherical models.

This PR cannot be merged until https://github.com/spacetelescope/gwcs/pull/284 is merged