### PR TITLE
Wrap lon to pm 180 range in temp code

### DIFF
--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -16,8 +16,8 @@ import gwcs
 
 if LooseVersion(gwcs.__version__) > '0.12.0':
     from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
-    _S2C = SphericalToCartesian(name='s2c')
-    _C2S = CartesianToSpherical(name='c2s')
+    _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+    _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
 from tweakwcs.tpwcs import TPWCS, JWSTgWCS
 

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -89,7 +89,7 @@ def test_mock_wcs_fails(crpix, cd):
 
 @pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_v2v3todet_roundtrips():
-    s2c = (Scale(1.0 / 3600.0) & Scale(1.0 / 3600.0)) | SphericalToCartesian()
+    s2c = (Scale(1.0 / 3600.0) & Scale(1.0 / 3600.0)) | SphericalToCartesian(wrap_lon_at=180)
 
     s = 1.0e-5
     crpix = np.random.random(2)

--- a/tweakwcs/tests/test_wcsutils.py
+++ b/tweakwcs/tests/test_wcsutils.py
@@ -14,14 +14,14 @@ import gwcs
 if LooseVersion(gwcs.__version__) > '0.12.0':
     from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
     _NO_JWST_SUPPORT = False
-    _S2C = SphericalToCartesian(name='s2c')
-    _C2S = CartesianToSpherical(name='c2s')
+    _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+    _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 else:
     _NO_JWST_SUPPORT = True
 
 
-# _S2C = SphericalToCartesian(name='s2c')
-# _C2S = CartesianToSpherical(name='c2s')
+# _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+# _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
 
 @pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
@@ -54,9 +54,9 @@ def test_cartesian_spherical_cartesian_roundtrip_rand():
 @pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_spherical_cartesian_spherical_roundtrip_ugrid():
     feps = 1000 * np.finfo(np.float64).eps
-    angles = np.linspace(0, 360, 13)
+    angles = np.linspace(-180, 180, 13)
     alpha0 = np.repeat(angles, angles.size)
-    delta0 = np.tile(angles / 2 - 90, angles.size)
+    delta0 = np.tile(angles / 2, angles.size)
     alpha, delta = _C2S(*_S2C(alpha0, delta0))
     assert np.allclose(alpha, alpha0, rtol=0, atol=feps)
     assert np.allclose(delta, delta0, rtol=0, atol=feps)

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -44,7 +44,7 @@ else:
     log.warning(
         "JWST support requires gwcs version > 12.1. "
         "To pip install minimal required version, do the following:\n"
-        "pip install git+https://github.com/spacetelescope/gwcs@ad951ec"
+        "pip install git+https://github.com/spacetelescope/gwcs@f638a8d"
     )
 
 
@@ -546,7 +546,7 @@ class JWSTgWCS(TPWCS):
             raise NotImplementedError(
                 "JWST support requires gwcs version > 12.1. "
                 "To pip install minimal required version, do the following:\n"
-                "pip install git+https://github.com/spacetelescope/gwcs@ad951ec"
+                "pip install git+https://github.com/spacetelescope/gwcs@f638a8d"
             )
 
         valid, message = self._check_wcs_structure(wcs)
@@ -638,8 +638,8 @@ class JWSTgWCS(TPWCS):
 
     @staticmethod
     def _tpcorr_init(v2_ref, v3_ref, roll_ref):
-        s2c = SphericalToCartesian(name='s2c', wrap_phi_at=180)
-        c2s = CartesianToSpherical(name='c2s', wrap_phi_at=180)
+        s2c = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+        c2s = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
         unit_conv = Scale(1.0 / 3600.0, name='arcsec_to_deg_1D')
         unit_conv = unit_conv & unit_conv

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -21,8 +21,8 @@ from spherical_geometry.polygon import SphericalPolygon
 import gwcs
 if LooseVersion(gwcs.__version__) > '0.12.0':
     from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
-    _S2C = SphericalToCartesian(name='s2c')
-    _C2S = CartesianToSpherical(name='c2s')
+    _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+    _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
 else:
     def _S2C(phi, theta):
@@ -36,7 +36,7 @@ else:
 
     def _C2S(x, y, z):
         h = np.hypot(x, y)
-        phi = np.mod(np.rad2deg(np.arctan2(y, x)), 360.0)
+        phi = np.rad2deg(np.arctan2(y, x))
         theta = np.rad2deg(np.arctan2(z, h))
         return phi, theta
 
@@ -52,8 +52,8 @@ __author__ = 'Mihai Cara'
 __all__ = ['convex_hull', 'RefCatalog', 'WCSImageCatalog', 'WCSGroupCatalog']
 
 
-# _S2C = SphericalToCartesian(name='s2c')
-# _C2S = CartesianToSpherical(name='c2s')
+# _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+# _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)


### PR DESCRIPTION
This PR removes wrapping of `lon` angle at 360 in the temporary code used for JWST WCS _in case when_ latest `gwcs`(i.e., master) is not available.