### PR TITLE
Fix parameter name and type formatting in docs

### DIFF
--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -52,14 +52,14 @@ def fit_wcs(refcat, imcat, tpwcs, fitgeom='general', nclip=3,
 
     Parameters
     ----------
-    refcat : astropy.table.Table
+    refcat: astropy.table.Table
         A reference source catalog. The catalog must contain ``'RA'`` and
         ``'DEC'`` columns which indicate reference source world
         coordinates (in degrees). An optional column in the catalog is
         the ``'weight'`` column, which when present, will be used in fitting.
         See ``Notes`` section for further details.
 
-    imcat : astropy.table.Table
+    imcat: astropy.table.Table
         Source catalog associated with an image whose WCS needs to be aligned
         by fitting a linear transformation to ``imcat`` source positions so as
         to align them to the same sources from the ``refcat`` catalog.
@@ -68,23 +68,23 @@ def fit_wcs(refcat, imcat, tpwcs, fitgeom='general', nclip=3,
         the catalog is the ``'weight'`` column, which when present, will be
         used in fitting. See ``Notes`` section for further details.
 
-    tpwcs : TPWCS
+    tpwcs: TPWCS
         A ``WCS`` associated with the image from which the catalog was derived.
         This ``TPWCS``-subclassed WCS corrector object must also define
         a tangent plane that will be used for fitting the two catalogs'
         sources and in which WCS corrections will be applied.
 
-    fitgeom : {'shift', 'rscale', 'general'}, optional
+    fitgeom: {'shift', 'rscale', 'general'}, optional
         The fitting geometry to be used in fitting the matched object lists.
         This parameter is used in fitting the offsets, rotations and/or scale
         changes from the matched object lists. The 'general' fit geometry
         allows for independent scale and rotation for each axis.
 
-    nclip : int, None, optional
+    nclip: int, None, optional
         Number (a non-negative integer) of clipping iterations in fit.
         Clipping will be turned off if ``nclip`` is either `None` or 0.
 
-    sigma : float, tuple of the form (float, str), optional
+    sigma: float, tuple of the form (float, str), optional
         When a tuple is provided, first value (a positive number)
         indicates the number of "fit error estimates" to use for clipping.
         The second value (a string) indicates the statistic to be
@@ -99,7 +99,7 @@ def fit_wcs(refcat, imcat, tpwcs, fitgeom='general', nclip=3,
 
     Returns
     -------
-    twwcs : TPWCS
+    twwcs: TPWCS
         "Tweaked" (aligned) ``WCS`` that contains tangent-plane corrections
         so that reference and image catalog sources better align in the tangent
         plane and therefore on the sky as well.
@@ -259,7 +259,7 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
 
     Parameters
     ----------
-    wcscat : tweakwcs.tpwcs.TPWCS, list of tweakwcs.tpwcs.TPWCS
+    wcscat: tweakwcs.tpwcs.TPWCS, list of tweakwcs.tpwcs.TPWCS
         A list of all `~tweakwcs.tpwcs.TPWCS`-derived WCS correctors whose
         ``meta`` dictionary **must** contain ``'catalog'``
         item with a non-empty table value of type `astropy.table.Table`.
@@ -286,14 +286,14 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
             This function modifies the WCS of ``TPWCS`` objects by calling
             their :py:meth:`~tweakwcs.tpwcs.TPWCS.set_correction` method.
 
-    refcat : astropy.table.Table, optional
+    refcat: astropy.table.Table, optional
         A reference source catalog. The catalog must contain ``'RA'`` and
         ``'DEC'`` columns which indicate reference source world
         coordinates (in degrees). An optional column in the catalog is
         the ``'weight'`` column, which when present, will be used in fitting.
         See ``Notes`` section for further details.
 
-    enforce_user_order : bool, optional
+    enforce_user_order: bool, optional
         Specifies whether images should be aligned in the order specified in
         the `file` input parameter or `align` should optimize the order
         of alignment by intersection area of the images. Default value (`True`)
@@ -302,7 +302,7 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
         alignment order. Alignment order optimization is available *only*
         when ``expand_refcat`` is `True`.
 
-    expand_refcat : bool, optional
+    expand_refcat: bool, optional
         Specifies whether to add new sources from just matched images to
         the reference catalog to allow next image to be matched against an
         expanded reference catalog. By delault, the reference catalog is not
@@ -317,29 +317,29 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
         IDs to all sources in all input catalogs **and** in the reference
         catalog in a separate column such as ``'uuid'``.
 
-    minobj : int, None, optional
+    minobj: int, None, optional
         Minimum number of identified objects from each input image to use
         in matching objects from other images. If the default `None` value is
         used then `align` will automatically deternmine the minimum number
         of sources from the value of the ``fitgeom`` parameter.
 
-    match : MatchCatalogs, function, None, optional
+    match: MatchCatalogs, function, None, optional
         A callable that takes two arguments: a reference catalog and an
         image catalog. Both catalogs will have columns ``'TPx'`` and
         ``'TPy'`` that represent the source coordinates in some common
         (to both catalogs) coordinate system.
 
-    fitgeom : {'shift', 'rscale', 'general'}, optional
+    fitgeom: {'shift', 'rscale', 'general'}, optional
         The fitting geometry to be used in fitting the matched object lists.
         This parameter is used in fitting the offsets, rotations and/or scale
         changes from the matched object lists. The 'general' fit geometry
         allows for independent scale and rotation for each axis.
 
-    nclip : int, None, optional
+    nclip: int, None, optional
         Number (a non-negative integer) of clipping iterations in fit.
         Clipping will be turned off if ``nclip`` is either `None` or 0.
 
-    sigma : float, tuple of the form (float, str), optional
+    sigma: float, tuple of the form (float, str), optional
         When a tuple is provided, first value (a positive number)
         indicates the number of "fit error estimates" to use for clipping.
         The second value (a string) indicates the statistic to be
@@ -354,7 +354,7 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
 
     Returns
     -------
-    eff_refcat : astropy.table.Table
+    eff_refcat: astropy.table.Table
         Effective reference catalog used for aligning all images. Depending
         on the values of the input parameters ``refcat``,
         ``enforce_user_order``, and ``expand_refcat``, effective
@@ -625,12 +625,12 @@ def overlap_matrix(images):
     Parameters
     ----------
 
-    images : list of WCSImageCatalog, WCSGroupCatalog, or RefCatalog
+    images: list of WCSImageCatalog, WCSGroupCatalog, or RefCatalog
         A list of catalogs that implement :py:meth:`intersection_area` method.
 
     Returns
     -------
-    m : numpy.ndarray
+    m: numpy.ndarray
         A `numpy.ndarray` of shape ``NxN`` where ``N`` is equal to the
         number of input images. Each non-diagonal element (i,j) of this matrix
         is the absolute value of the area of overlap on the sky between i-th
@@ -659,10 +659,10 @@ def max_overlap_pair(images, enforce_user_order):
     Parameters
     ----------
 
-    images : list of WCSImageCatalog, WCSGroupCatalog, or RefCatalog
+    images: list of WCSImageCatalog, WCSGroupCatalog, or RefCatalog
         A list of catalogs that implement :py:meth:`intersection_area` method.
 
-    enforce_user_order : bool
+    enforce_user_order: bool
         When ``enforce_user_order`` is `True`, a pair of images will be
         returned **in the same order** as they were arranged in the ``images``
         input list. That is, image overlaps will be ignored.
@@ -733,13 +733,13 @@ def max_overlap_image(refimage, images, enforce_user_order):
 
     Parameters
     ----------
-    refimage : RefCatalog
+    refimage: RefCatalog
         Reference catalog.
 
-    images : list of WCSImageCatalog, or WCSGroupCatalog
+    images: list of WCSImageCatalog, or WCSGroupCatalog
         A list of catalogs that implement :py:meth:`intersection_area` method.
 
-    enforce_user_order : bool
+    enforce_user_order: bool
         When ``enforce_user_order`` is `True`, returned image is the first
         image from the ``images`` input list regardless ofimage overlaps.
 

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -83,12 +83,12 @@ def inv(m):
 
     Parameters
     ----------
-    m : numpy.ndarray
+    m: numpy.ndarray
         A 2D *square* matrix of type `numpy.ndarray`.
 
     Returns
     -------
-    invm : numpy.ndarray
+    invm: numpy.ndarray
         Inverse matrix of the input matrix ``m``: a 2D *square* `numpy.ndarray`
         of type ``numpy.longdouble`` on systems on which it is more accurate
         than ``numpy.float64``.

--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -38,13 +38,13 @@ class MatchCatalogs(ABC):
         Parameters
         ----------
 
-        refcat : astropy.table.Table
+        refcat: astropy.table.Table
             A reference source catalog. Reference catalog must contain
             ``'TPx'`` and ``'TPy'`` columns that provide undistorted
             (distortion-correction applied) source coordinates coordinate
             system common (shared) with the image catalog ``imcat``.
 
-        imcat : astropy.table.Table
+        imcat: astropy.table.Table
             Source catalog associated with an image. Image catalog must contain
             ``'TPx'`` and ``'TPy'`` columns that provide undistorted
             (distortion-correction applied) source coordinates coordinate
@@ -52,7 +52,7 @@ class MatchCatalogs(ABC):
 
         Returns
         -------
-        (refcat_idx, imcat_idx) : tuple of numpy.ndarray
+        (refcat_idx, imcat_idx): tuple of numpy.ndarray
             A tuple of two 1D `numpy.ndarray` containing indices of matched
             sources in the ``refcat`` and ``imcat`` catalogs accordingly.
 
@@ -80,10 +80,10 @@ class TPMatch(MatchCatalogs):
         Parameters
         ----------
 
-        searchrad : float, optional
+        searchrad: float, optional
             The search radius for a match (in units of the tangent plane).
 
-        separation : float, optional
+        separation: float, optional
             The  minimum  separation in the tangent plane (in units of
             the tangent plane) for sources in the image and reference
             catalogs in order to be considered to be disctinct sources.
@@ -93,22 +93,22 @@ class TPMatch(MatchCatalogs):
             :py:func:`~stsci.stimage.xyxymatch` for use in matching the object
             lists from each image with the reference catalog's object list.
 
-        use2dhist : bool, optional
+        use2dhist: bool, optional
             Use 2D histogram to find initial offset?
 
-        xoffset : float, optional
+        xoffset: float, optional
             Initial estimate for the offset in X (in units of the tangent
             plane) between the sources in the image and the reference catalogs.
             This offset will be used for all input images provided.
             This parameter is ignored when ``use2dhist`` is `True`.
 
-        yoffset : float, optional
+        yoffset: float, optional
             Initial estimate for the offset in Y (in units of the tangent
             plane) between the sources in the image and the reference catalogs.
             This offset will be used for all input images provided.
             This parameter is ignored when ``use2dhist`` is `True`.
 
-        tolerance : float, optional
+        tolerance: float, optional
             The matching tolerance (in units of the tangent plane) after
             applying an initial solution derived from the 'triangles'
             algorithm.  This parameter gets passed directly to
@@ -143,7 +143,7 @@ class TPMatch(MatchCatalogs):
         Parameters
         ----------
 
-        refcat : astropy.table.Table
+        refcat: astropy.table.Table
             A reference source catalog. When a tangent-plane ``WCS`` is
             provided through ``tp_wcs``, the catalog must contain ``'RA'`` and
             ``'DEC'`` columns which indicate reference source world
@@ -153,7 +153,7 @@ class TPMatch(MatchCatalogs):
             coordinates in some *tangent plane*. In this case, the ``'RA'``
             and ``'DEC'`` columns in the ``refcat`` catalog will be ignored.
 
-        imcat : astropy.table.Table
+        imcat: astropy.table.Table
             Source catalog associated with an image. Must contain ``'x'`` and
             ``'y'`` columns which indicate source coordinates (in pixels) in
             the associated image. Alternatively, when ``tp_wcs`` is `None`,
@@ -163,7 +163,7 @@ class TPMatch(MatchCatalogs):
             ``refcat``'s tangent plane coordinates. In this case, the ``'x'``
             and ``'y'`` columns in the ``imcat`` catalog will be ignored.
 
-        tp_wcs : TPWCS, None, optional
+        tp_wcs: TPWCS, None, optional
             A ``WCS`` that defines a tangent plane onto which both
             reference and image catalog sources can be projected. For this
             reason, ``tp_wcs`` is associated with the image in which sources
@@ -175,7 +175,7 @@ class TPMatch(MatchCatalogs):
 
         Returns
         -------
-        (refcat_idx, imcat_idx) : tuple of numpy.ndarray
+        (refcat_idx, imcat_idx): tuple of numpy.ndarray
             A tuple of two 1D `numpy.ndarray` containing indices of matched
             sources in the ``refcat`` and ``imcat`` catalogs accordingly.
 
@@ -357,26 +357,26 @@ def _find_peak(data, peak_fit_box=5, mask=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data: numpy.ndarray
         2D data.
 
-    peak_fit_box : int, optional
+    peak_fit_box: int, optional
         Size (in pixels) of the box around the initial estimate of the maximum
         to be used for quadratic fitting from which peak location is computed.
         It is assumed that fitting box is a square with sides of length
         given by ``peak_fit_box``.
 
-    mask : numpy.ndarray, optional
+    mask: numpy.ndarray, optional
         A boolean type `~numpy.ndarray` indicating "good" pixels in image data
         (`True`) and "bad" pixels (`False`). If not provided all pixels
         in `image_data` will be used for fitting.
 
     Returns
     -------
-    coord : tuple of float
+    coord: tuple of float
         A pair of coordinates of the peak.
 
-    fit_status : str
+    fit_status: str
         Status of the peak search. Currently the following values can be
         returned:
 
@@ -393,7 +393,7 @@ def _find_peak(data, peak_fit_box=5, mask=None):
           either due to too few points to perform a fit or due to a
           failure of the polynomial fit.
 
-    fit_box : a tuple of two tuples
+    fit_box: a tuple of two tuples
         A tuple of two tuples of the form ``((x1, x2), (y1, y2))`` that
         indicates pixel ranges used for fitting (these indices can be used
         directly for slicing input data)

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -58,10 +58,10 @@ class TPWCS(ABC):
         """
         Parameters
         ----------
-        wcs : ``WCS object``
+        wcs: ``WCS object``
             A `WCS` object supported by a child class.
 
-        meta : dict, None, optional
+        meta: dict, None, optional
             Dictionary that will be merged to the object's ``meta`` fields.
 
         """
@@ -95,18 +95,18 @@ class TPWCS(ABC):
 
         Parameters
         ----------
-        matrix : list, numpy.ndarray, optional
+        matrix: list, numpy.ndarray, optional
             A ``2x2`` array or list of lists coefficients representing scale,
             rotation, and/or skew transformations.
 
-        shift : list, numpy.ndarray, optional
+        shift: list, numpy.ndarray, optional
             A list of two coordinate shifts to be applied to coordinates
             *before* ``matrix`` transformations are applied.
 
-        meta : dict, None, optional
+        meta: dict, None, optional
             Dictionary that will be merged to the object's ``meta`` fields.
 
-        **kwargs : optional parameters
+        **kwargs: optional parameters
             Optional parameters for the WCS corrector.
 
         """
@@ -177,18 +177,18 @@ class TPWCS(ABC):
 
         Parameters
         ----------
-        x : int, float
+        x: int, float
             X-coordinate of the pixel in the detector's coordinate system
             near which pixel scale in the tangent plane needs to be estimated.
 
-        y : int, float
+        y: int, float
             Y-coordinate of the pixel in the detector's coordinate system
             near which pixel scale in the tangent plane needs to be estimated.
 
         Returns
         -------
 
-        pscale : float
+        pscale: float
             Pixel scale [in units used in the tangent plane coordinate system]
             in the tangent plane near a location specified by detector
             coordinates ``x`` and ``y``.
@@ -212,7 +212,7 @@ class TPWCS(ABC):
 
         Returns
         -------
-        pscale : float
+        pscale: float
             Pixel scale [in units used in the tangent plane coordinate system]
             in the tangent plane near a location in the detector's plane
             corresponding to the origin of the tangent plane.
@@ -252,7 +252,7 @@ class FITSWCS(TPWCS):
         Parameters
         ----------
 
-        wcs : astropy.wcs.WCS
+        wcs: astropy.wcs.WCS
             An `astropy.wcs.WCS` object.
 
         """
@@ -330,18 +330,18 @@ class FITSWCS(TPWCS):
 
         Parameters
         ----------
-        matrix : list, numpy.ndarray
+        matrix: list, numpy.ndarray
             A ``2x2`` array or list of lists coefficients representing scale,
             rotation, and/or skew transformations.
 
-        shift : list, numpy.ndarray
+        shift: list, numpy.ndarray
             A list of two coordinate shifts to be applied to coordinates
             *before* ``matrix`` transformations are applied.
 
-        meta : dict, None, optional
+        meta: dict, None, optional
             Dictionary that will be merged to the object's ``meta`` fields.
 
-        **kwargs : optional parameters
+        **kwargs: optional parameters
             Optional parameters for the WCS corrector. `FITSWCS` ignores these
             arguments (except for storing them in the ``meta`` attribute).
 
@@ -519,26 +519,26 @@ class JWSTgWCS(TPWCS):
         """
         Parameters
         ----------
-        wcs : GWCS
+        wcs: GWCS
             A `GWCS` object.
 
-        wcsinfo : dict
+        wcsinfo: dict
             A dictionary containing reference angles of ``JWST`` instrument
             provided in the ``wcsinfo`` property of ``JWST`` meta data.
 
             This dictionary **must contain** the following keys and values:
 
 
-            'v2_ref' : float
+            'v2_ref': float
                 V2 position of the reference point in arc seconds.
 
-            'v3_ref' : float
+            'v3_ref': float
                 V3 position of the reference point in arc seconds.
 
-            'roll_ref' : float
+            'roll_ref': float
                 Roll angle in degrees.
 
-        meta : dict, None, optional
+        meta: dict, None, optional
             Dictionary that will be merged to the object's ``meta`` fields.
 
         """
@@ -735,18 +735,18 @@ class JWSTgWCS(TPWCS):
 
         Parameters
         ----------
-        matrix : list, numpy.ndarray
+        matrix: list, numpy.ndarray
             A ``2x2`` array or list of lists coefficients representing scale,
             rotation, and/or skew transformations.
 
-        shift : list, numpy.ndarray
+        shift: list, numpy.ndarray
             A list of two coordinate shifts to be applied to coordinates
             *before* ``matrix`` transformations are applied.
 
-        meta : dict, None, optional
+        meta: dict, None, optional
             Dictionary that will be merged to the object's ``meta`` fields.
 
-        **kwargs : optional parameters
+        **kwargs: optional parameters
             Optional parameters for the WCS corrector. `JWSTgWCS` ignores these
             arguments (except for storing them in the ``meta`` attribute).
 

--- a/tweakwcs/utils/jwst_utils.py
+++ b/tweakwcs/utils/jwst_utils.py
@@ -36,7 +36,7 @@ def assign_jwst_tweakwcs_groups(images):
 
     Parameters
     ----------
-    images : list of str or jwst.datamodels.DataModel
+    images: list of str or jwst.datamodels.DataModel
         A list of string file names to ``JWST`` data or
         `jwst.datamodels.DataModel` objects. On return, these data models
         or files will contain ``tweakwcs_group_id`` attribute in their

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -82,25 +82,25 @@ class WCSImageCatalog(object):
         """
         Parameters
         ----------
-        catalog : astropy.table.Table
+        catalog: astropy.table.Table
             Source catalog associated with an image. Must contain ``'x'`` and
             ``'y'`` columns which indicate source coordinates (in pixels) in
             the associated image.
 
-        tpwcs : TPWCS
+        tpwcs: TPWCS
             ``TPWCS``-derived tangent-plane WCS corrector object associated
             with the image from which the catalog was derived.
 
-        name : str, None, optional
+        name: str, None, optional
             Image catalog's name. This is used to identify catalog during
             logging. If ``name`` is `None`, the ``name`` of this
             ``WCSImageCatalog`` object will be set to ``'Unknown'``.
 
-        group_id : hashable, None, optional
+        group_id: hashable, None, optional
             Group ID that may be used for identifying catalogs that need
             to be aligned together. ``group_id`` must be hashable.
 
-        meta : dict, optional
+        meta: dict, optional
             Additional information about image, catalog, and/or WCS to be
             stored (for convenience) within `WCSImageCatalog` object.
 
@@ -134,7 +134,7 @@ class WCSImageCatalog(object):
 
         Parameters
         ----------
-        tpwcs : TPWCS
+        tpwcs: TPWCS
             ``TPWCS``-derived tangent-plane WCS corrector object associated
             with the image from which the catalog was extracted.
 
@@ -285,13 +285,13 @@ class WCSImageCatalog(object):
 
         Parameters
         ----------
-        wcsim : WCSImageCatalog, WCSGroupCatalog, SphericalPolygon
+        wcsim: WCSImageCatalog, WCSGroupCatalog, SphericalPolygon
             Another object that should be intersected with this
             `WCSImageCatalog`.
 
         Returns
         -------
-        polygon : SphericalPolygon
+        polygon: SphericalPolygon
             A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `WCSImageCatalog` and `wcsim`.
 
@@ -333,7 +333,7 @@ class WCSImageCatalog(object):
 
         Parameters
         ----------
-        stepsize : int, None, optional
+        stepsize: int, None, optional
             Indicates the maximum separation between two adjacent vertices
             of the bounding polygon along each side of the image. Corners
             of the image are included automatically. If `stepsize` is `None`,
@@ -472,10 +472,10 @@ class WCSGroupCatalog(object):
         """
         Parameters
         ----------
-        images : list of WCSImageCatalog
+        images: list of WCSImageCatalog
             A list of `WCSImageCatalog` image catalogs.
 
-        name : str, None, optional
+        name: str, None, optional
             Name of the group.
 
         """
@@ -535,13 +535,13 @@ class WCSGroupCatalog(object):
 
         Parameters
         ----------
-        wcsim : WCSImageCatalog, WCSGroupCatalog, SphericalPolygon
+        wcsim: WCSImageCatalog, WCSGroupCatalog, SphericalPolygon
             Another object that should be intersected with this
             `WCSGroupCatalog`.
 
         Returns
         -------
-        polygon : SphericalPolygon
+        polygon: SphericalPolygon
             A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `WCSGroupCatalog` and `wcsim`.
 
@@ -599,7 +599,7 @@ class WCSGroupCatalog(object):
 
         Returns
         -------
-        group_catalog : astropy.table.Table
+        group_catalog: astropy.table.Table
             Combined group catalog.
 
         """
@@ -738,7 +738,7 @@ class WCSGroupCatalog(object):
 
         Parameters
         ----------
-        tanplane_wcs : ImageGWCS
+        tanplane_wcs: ImageGWCS
             A `ImageGWCS` object that will provide transformations to
             the tangent plane to which sources of this catalog a should be
             "projected".
@@ -765,11 +765,11 @@ class WCSGroupCatalog(object):
 
         Parameters
         ----------
-        refcat : RefCatalog
+        refcat: RefCatalog
             A `RefCatalog` object that contains a catalog of reference sources
             as well as a valid reference WCS.
 
-        match : MatchCatalogs, function, None, optional
+        match: MatchCatalogs, function, None, optional
             A callable that takes two arguments: a reference catalog and an
             image catalog. Both catalogs will have columns ``'TPx'`` and
             ``'TPy'`` that represent the source coordinates in some common
@@ -851,26 +851,26 @@ class WCSGroupCatalog(object):
 
         Parameters
         ----------
-        refcat : RefCatalog
+        refcat: RefCatalog
             A `RefCatalog` object that contains a catalog of reference sources.
 
-        tanplane_wcs : ImageGWCS
+        tanplane_wcs: ImageGWCS
             A `ImageGWCS` object that will provide transformations to
             the tangent plane to which sources of this catalog a should be
             "projected".
 
-        fitgeom : {'shift', 'rscale', 'general'}, optional
+        fitgeom: {'shift', 'rscale', 'general'}, optional
             The fitting geometry to be used in fitting the matched object
             lists. This parameter is used in fitting the offsets, rotations
             and/or scale changes from the matched object lists. The 'general'
             fit geometry allows for independent scale and rotation for
             each axis.
 
-        nclip : int, None, optional
+        nclip: int, None, optional
             Number (a non-negative integer) of clipping iterations in fit.
             Clipping will be turned off if ``nclip`` is either `None` or 0.
 
-        sigma : float, tuple of the form (float, str), optional
+        sigma: float, tuple of the form (float, str), optional
             When a tuple is provided, first value (a positive number)
             indicates the number of "fit error estimates" to use for clipping.
             The second value (a string) indicates the statistic to be
@@ -1079,15 +1079,15 @@ class WCSGroupCatalog(object):
 
         Parameters
         ----------
-        refcat : RefCatalog
+        refcat: RefCatalog
             A `RefCatalog` object that contains a catalog of reference sources
             as well as a valid reference WCS.
 
-        match : MatchCatalogs, function, None, optional
+        match: MatchCatalogs, function, None, optional
             A callable that takes two arguments: a reference catalog and an
             image catalog.
 
-        minobj : int, None, optional
+        minobj: int, None, optional
             Minimum number of identified objects from each input image to use
             in matching objects from other images. If the default `None` value
             is used then `align` will automatically deternmine the minimum
@@ -1097,20 +1097,20 @@ class WCSGroupCatalog(object):
             is smaller than the value of ``minobj`` in which case this
             method will return `False`.
 
-        fitgeom : {'shift', 'rscale', 'general'}, optional
+        fitgeom: {'shift', 'rscale', 'general'}, optional
             The fitting geometry to be used in fitting the matched object
             lists. This parameter is used in fitting the offsets, rotations
             and/or scale changes from the matched object lists. The 'general'
             fit geometry allows for independent scale and rotation for each
             axis. This parameter is ignored if ``match`` is `False`.
 
-        nclip : int, None, optional
+        nclip: int, None, optional
             Number (a non-negative integer) of clipping iterations in fit.
             Clipping will be turned off if ``nclip`` is either `None` or 0.
 
             This parameter is ignored if ``match`` is `False`.
 
-        sigma : float, tuple of the form (float, str), optional
+        sigma: float, tuple of the form (float, str), optional
             When a tuple is provided, first value (a positive number)
             indicates the number of "fit error estimates" to use for clipping.
             The second value (a string) indicates the statistic to be
@@ -1237,17 +1237,17 @@ class RefCatalog(object):
         """
         Parameters
         ----------
-        catalog : astropy.table.Table
+        catalog: astropy.table.Table
             Reference catalog.
 
             .. note::
                 Reference catalogs (:py:class:`~astropy.table.Table`)
                 *must* contain *both* ``'RA'`` and ``'DEC'`` columns.
 
-        name : str, None, optional
+        name: str, None, optional
             Name of the reference catalog.
 
-        footprint_tol : float, optional
+        footprint_tol: float, optional
             Matching tolerance in arcsec. This is used to estimate catalog's
             footprint when catalog contains only one or two sources.
 
@@ -1322,13 +1322,13 @@ class RefCatalog(object):
 
         Parameters
         ----------
-        wcsim : WCSImageCatalog, WCSGroupCatalog, RefCatalog, SphericalPolygon
+        wcsim: WCSImageCatalog, WCSGroupCatalog, RefCatalog, SphericalPolygon
             Another object that should be intersected with this
             `WCSImageCatalog`.
 
         Returns
         -------
-        polygon : SphericalPolygon
+        polygon: SphericalPolygon
             A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `WCSImageCatalog` and `wcsim`.
 
@@ -1477,7 +1477,7 @@ class RefCatalog(object):
 
         Parameters
         ----------
-        catalog : astropy.table.Table
+        catalog: astropy.table.Table
             A catalog of new sources to be added to the existing reference
             catalog. `catalog` *must* contain *both* ``'RA'`` and ``'DEC'``
             columns.
@@ -1514,7 +1514,7 @@ class RefCatalog(object):
 
         Parameters
         ----------
-        tanplane_wcs : ImageGWCS
+        tanplane_wcs: ImageGWCS
             A `ImageGWCS` object that will provide transformations to
             the tangent plane to which sources of this catalog a should be
             "projected".
@@ -1544,12 +1544,12 @@ Convex_hull/Monotone_chain>`_
     Parameters
     ----------
 
-    points : list of tuples
+    points: list of tuples
         An iterable sequence of (x, y) pairs representing the points.
 
     Returns
     -------
-    Output : list
+    Output: list
         A list of vertices of the convex hull in counter-clockwise order,
         starting from the vertex with the lexicographically smallest
         coordinates.


### PR DESCRIPTION
Fix issues with formatting of parameters and types in the documentation.