### PR TITLE
Rename and re-organize fields in the fit_info dictionary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,15 @@ Release Notes
 0.6.0 (unreleased)
 ==================
 
+- Significant re-organization of the ``fit_info`` dictionary. ``rot`` now
+  becomes ``proper_rot`` and ``rotxy`` now becomes ``rot`` containing only
+  ``rotx`` and ``roty``. Also, ``scale`` now is a tuple of only two scales
+  ``sx`` and ``sy``. The geometric mean scale is now a separate field
+  ``'<scale>'`` as well as the arithmetic mean of rotation angles
+  (``'<rot>'``). Finally, ``'offset'`` in the fit functions from the
+  ``linearfit`` module was renamed to ``'shift'`` in order to match the
+  same field returned by functions from the ``imalign`` module. [#105]
+
 - Linear fit functions now return the fit matrix ``F`` instead of its
   transpose. [#100]
 

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -142,29 +142,68 @@ def fit_wcs(refcat, imcat, tpwcs, fitgeom='general', nclip=3,
     key value of the ``meta`` attribute of the returned ``TPWCS`` object.
     ``'fit_info'`` is a dictionary with the following items:
 
-        * **'fitgeom'**: the value of the ``fitgeom`` argument
-        * **'eff_minobj'**: effective value of the ``minobj`` parameter
-        * **'matrix'**: computed rotation matrix
-        * **'shift'**: offset along X- and Y-axis
-        * **'center'**: center of rotation in geometric transformations
-        * **'fitmask'**: boolean array indicating (with `True`) sources
-          **used** for fitting
-        * **'rot'**: rotation angle as if rotation is a proper rotation
-        * **'proper'**: Indicates whether the rotation is a proper rotation
-          (boolean)
-        * **'rotxy'**: a tuple of (rotation of the X-axis, rotation of the
-          Y-axis, mean rotation, computed skew)
-        * **'scale'**: a tuple of (mean scale, scale along X-axis, scale along
-          Y-axis)
-        * **'skew'**: computed skew
+        * **'shift'**: A ``numpy.ndarray`` with two components of the
+          computed shift.
+
+        * **'matrix'**: A ``2x2`` ``numpy.ndarray`` with the computed
+          generalized rotation matrix.
+
+        * **'proper_rot'**: Rotation angle (degree) as if the rotation is
+          proper.
+
+        * **'rot'**: A tuple of ``(rotx, roty)`` - the rotation angles with
+          regard to the ``X`` and ``Y`` axes.
+
+        * **'<rot>'**: *Arithmetic mean* of the angles of rotation around
+          ``X`` and ``Y`` axes.
+
+        * **'scale'**: A tuple of ``(sx, sy)`` - scale change in the direction
+          of the ``X`` and ``Y`` axes.
+
+        * **'<scale>'**: *Geometric mean* of scales ``sx`` and ``sy``.
+
+        * **'skew'**: Computed skew.
+
+        * **'proper'**: a boolean indicating whether the rotation is proper.
+
+        * **'fitgeom'**: Fit geometry (allowed transformations) used for
+          fitting data (to minimize residuals). This is copy of the input
+          argument ``fitgeom``.
+
+        * **'center'**: Center of rotation in the *tangent plane* of the
+          computed linear transformations.
+
+        * **'fitmask'**: A boolean array indicating which source positions
+          where used for fitting (`True`) and which were clipped out
+          (`False`). **NOTE:** For weighted fits, positions with zero
+          weights are automatically excluded from the fits.
+
+        * **'eff_nclip'**: Effective number of clipping iterations
+
         * **'rmse'**: fit Root-Mean-Square Error in *tangent plane*
           coordinates of corrected image source positions from reference
           source positions.
+
         * **'mae'**: fit Mean Absolute Error in *tangent plane*
           coordinates of corrected image source positions from reference
           source positions.
+
         * **'std'**: Norm of the standard deviation of the residuals
           in *tangent plane* along each axis.
+
+        * **'resids'**: An array of residuals of the fit in the
+          *tangent plane*.
+
+          **NOTE:** Only the residuals for the "valid" points are reported
+          here. Therefore the length of this array may be smaller than the
+          length of input arrays of positions.
+
+        * **'fit_RA'**: first (corrected) world coordinate of input source
+          positions used in fitting.
+
+        * **'fit_DEC'**: second (corrected) world coordinate of input
+          source positions used in fitting.
+
         * **'status'**: Alignment status. Currently two possible status are
           possible ``'SUCCESS'`` or ``'FAILED: reason for failure'``.
           When alignment failed, the reason for failure is provided after
@@ -221,7 +260,7 @@ def fit_wcs(refcat, imcat, tpwcs, fitgeom='general', nclip=3,
 def align_wcs(wcscat, refcat=None, enforce_user_order=True,
               expand_refcat=False, minobj=None, match=TPMatch(),
               fitgeom='general', nclip=3, sigma=(3.0, 'rmse')):
-    """
+    r"""
     Align (groups of) image catalogs by adjusting the parameters of their
     WCS based on fits between matched sources in these catalogs and a reference
     catalog which may be automatically created from one of the input ``wcscat``
@@ -364,7 +403,7 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
 
     Notes
     -----
-    **Weights:**
+    **1. Weights:**
 
     When fitting image sources to reference catalog sources, we can specify
     which sources have higher weights. This can be done by assigning a "weight"
@@ -402,7 +441,7 @@ def align_wcs(wcscat, refcat=None, enforce_user_order=True,
         When image catalogs contain optional ``'weight'`` column, then
         all image catalogs in a group must contain this column.
 
-    **``'fit_info'``**
+    **2.** ``'fit_info'``:
 
     Upon completion, this function will add ``'fit_info'``
     item (itself a dictionary) to input object's ``meta`` dictionary.

--- a/tweakwcs/tests/test_imalign.py
+++ b/tweakwcs/tests/test_imalign.py
@@ -228,9 +228,9 @@ def test_align_wcs_simple_ref_image_general(shift, rot, scale, fitgeom,
     assert tpwcs.meta['fit_info']['fitgeom'] == fitgeom
     assert np.allclose(tpwcs.meta['fit_info']['shift'], shift)
     assert np.allclose(tpwcs.meta['fit_info']['matrix'], m)
-    assert np.allclose(tpwcs.meta['fit_info']['rotxy'][:2], rot)
+    assert np.allclose(tpwcs.meta['fit_info']['rot'], rot)
     assert tpwcs.meta['fit_info']['proper']
-    assert np.allclose(tpwcs.meta['fit_info']['scale'][1:], scale)
+    assert np.allclose(tpwcs.meta['fit_info']['scale'], scale)
     assert tpwcs.meta['fit_info']['rmse'] < 1.0e-8
 
 
@@ -254,9 +254,9 @@ def test_align_wcs_simple_twpwcs_ref(mock_fits_wcs):
     assert tpwcs.meta['fit_info']['fitgeom'] == 'general'
     assert np.allclose(tpwcs.meta['fit_info']['shift'], shift)
     assert np.allclose(tpwcs.meta['fit_info']['matrix'], m)
-    assert np.allclose(tpwcs.meta['fit_info']['rotxy'][:2], rot)
+    assert np.allclose(tpwcs.meta['fit_info']['rot'], rot)
     assert tpwcs.meta['fit_info']['proper']
-    assert np.allclose(tpwcs.meta['fit_info']['scale'][1:], scale)
+    assert np.allclose(tpwcs.meta['fit_info']['scale'], scale)
     assert tpwcs.meta['fit_info']['rmse'] < 1.0e-8
 
 

--- a/tweakwcs/tests/test_linearfit.py
+++ b/tweakwcs/tests/test_linearfit.py
@@ -271,7 +271,7 @@ def test_iter_linear_fit_special_cases(ideal_large_data, nclip, sigma,
                                     nclip=nclip, center=(0, 0), sigma=1,
                                     clip_accum=clip_accum)
 
-    assert np.allclose(fit['offset'], shift, rtol=0, atol=atol)
+    assert np.allclose(fit['shift'], shift, rtol=0, atol=atol)
     assert np.allclose(fit['matrix'], rmat, rtol=0, atol=atol)
 
 
@@ -287,7 +287,7 @@ def test_iter_linear_fit_1point(weights):
     fit = linearfit.iter_linear_fit(xy, xy + shifts, wxy=wxy, wuv=wuv,
                                     fitgeom='shift', nclip=0)
 
-    assert np.allclose(fit['offset'], -shifts, rtol=0, atol=_ATOL)
+    assert np.allclose(fit['shift'], -shifts, rtol=0, atol=_ATOL)
     assert np.allclose(fit['matrix'], np.identity(2), rtol=0, atol=_ATOL)
 
 
@@ -390,7 +390,7 @@ def test_iter_linear_fit_clip_style(ideal_large_data, weight_data,
 
     shift_with_center = np.dot(rmat, fit['center']) - fit['center'] + shift
 
-    assert np.allclose(fit['offset'], shift_with_center, rtol=0, atol=atol)
+    assert np.allclose(fit['shift'], shift_with_center, rtol=0, atol=atol)
     assert np.allclose(fit['matrix'], rmat, rtol=0, atol=atol)
     assert np.allclose(fit['rmse'], 0, rtol=0, atol=atol)
     assert np.allclose(fit['mae'], 0, rtol=0, atol=atol)


### PR DESCRIPTION
This PR re-organizes how results of the fits are being reported. In my opinion now the structure of the `fits_info` dictionary is a little bit more clear.

``rot`` now   becomes ``proper_rot`` and ``rotxy`` now becomes ``rot`` containing only  ``rotx`` and ``roty``. Also, ``scale`` now is a tuple of only two scales ``sx`` and ``sy``. The geometric mean scale is now a separate field ``'<scale>'`` as well as the arithmetic mean of rotation angles (``'<rot>'``). Finally, ``'offset'`` in the fit functions from the ``linearfit`` module was renamed to ``'shift'`` in order to match the same field returned by functions from the ``imalign`` module.

This change is backward incompatible but the only user(s) who might be affected, to the best of my knowledge, are @stsci-hack and @mdlpstsci.