### PR TITLE
Fix a bug in alignment of multi-chip FITS images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Release Notes
 0.6.0 (unreleased)
 ==================
 
+- Bug fix for alignment of multi-chip FITS images: correction of how
+  transformations from the reference tangent plane are converted to
+  individual images' tangent planes. [#106]
+
 - Significant re-organization of the ``fit_info`` dictionary. ``rot`` now
   becomes ``proper_rot`` and ``rotxy`` now becomes ``rot`` containing only
   ``rotx`` and ``roty``. Also, ``scale`` now is a tuple of only two scales

--- a/tweakwcs/tests/test_imalign.py
+++ b/tweakwcs/tests/test_imalign.py
@@ -202,7 +202,6 @@ def test_align_wcs_tpwcs_type(mock_fits_wcs):
 ])
 def test_align_wcs_simple_ref_image_general(shift, rot, scale, fitgeom,
                                             weighted, mock_fits_wcs):
-    crpix = mock_fits_wcs.wcs.crpix - 1
     xy = 1024 * np.random.random((100, 2))
     if weighted:
         w = np.ones((100, 1))
@@ -211,7 +210,7 @@ def test_align_wcs_simple_ref_image_general(shift, rot, scale, fitgeom,
     else:
         names = ('x', 'y')
     m = build_fit_matrix(rot, scale)
-    xyr = np.dot(xy[:, :2] - crpix, m.T) + crpix + shift
+    xyr = np.dot(xy[:, :2], m.T) + shift
     imcat = Table(xy, names=names)
     radec = mock_fits_wcs.wcs_pix2world(xyr, 0)
     if weighted:
@@ -239,10 +238,9 @@ def test_align_wcs_simple_twpwcs_ref(mock_fits_wcs):
     rot = (15, 17)
     scale = (1.0123, 0.9876)
 
-    crpix = mock_fits_wcs.wcs.crpix - 1
     xy = 1024 * np.random.random((100, 2))
     m = build_fit_matrix(rot, scale)
-    xyr = np.dot(xy - crpix, m.T) + crpix + shift
+    xyr = np.dot(xy, m.T) + shift
     imcat = Table(xy, names=('x', 'y'))
     refcat = Table(xyr, names=('x', 'y'))
     tpwcs = FITSWCS(mock_fits_wcs, meta={'catalog': imcat})

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -162,7 +162,7 @@ def test_jwst_wcs_corr_are_being_combined(mock_jwst_wcs):
     assert 'v2v3corr' in wc.wcs.available_frames
 
     matrix2 = np.linalg.inv(matrix1)
-    shift2 = -np.dot(matrix1, shift1)
+    shift2 = -np.dot(matrix2, shift1)
     wc = tpwcs.JWSTgWCS(
         wc.wcs, {'v2_ref': 123.0, 'v3_ref': 500.0, 'roll_ref': 115.0}
     )
@@ -417,10 +417,10 @@ def test_fitswcs_coord_transforms(mock_fits_wcs):
 
     assert np.allclose(wc.det_to_world(499, 511), (12, 24), atol=_ATOL)
     assert np.allclose(wc.world_to_det(12, 24), (499, 511), atol=_ATOL)
-    assert np.allclose(wc.det_to_tanp(499, 511), (0, 0), atol=_ATOL)
-    assert np.allclose(wc.tanp_to_det(0, 0), (499, 511), atol=_ATOL)
-    assert np.allclose(wc.world_to_tanp(12, 24), (0, 0), atol=1e-8)
-    assert np.allclose(wc.tanp_to_world(0, 0), (12, 24), atol=_ATOL)
+    assert np.allclose(wc.det_to_tanp(499, 511), (499, 511), atol=_ATOL)
+    assert np.allclose(wc.tanp_to_det(499, 511), (499, 511), atol=_ATOL)
+    assert np.allclose(wc.world_to_tanp(12, 24), (499, 511), atol=1e-8)
+    assert np.allclose(wc.tanp_to_world(499, 511), (12, 24), atol=_ATOL)
 
 
 def test_fitswcs_bbox(mock_fits_wcs):


### PR DESCRIPTION
This PR fixes a bug in the alignment of multi-chip FITS WCS images resulting in relative mis-alignment of chips. Only the first chip was aligned correctly. The issue was reported by @stsci-hack 

The root-cause of the issue appears to be due to the code being originally designed to work with JWST's `gwcs` which required special transformation of transformations computed in the reference tangent plane to image's tangent plane. When FITS code was ported from `tweakreg` I missed that _that_ code was already doing this transformation and so it was applied twice.