### PR TITLE
Make support for JWST WCS optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ PACKAGE_DATA = {
 INSTALL_REQUIRES = [
     'numpy',
     'astropy>=3.1',
-    'gwcs',
     'stsci.stimage',
     'stsci.imagestats',
     'spherical_geometry',

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -9,18 +9,25 @@ import pytest
 from distutils.version import LooseVersion
 
 import numpy as np
-
-import gwcs
-if LooseVersion(gwcs.__version__) > '0.12.0':
-    from gwcs.geometry import SphericalToCartesian
-    _NO_JWST_SUPPORT = False
-else:
-    _NO_JWST_SUPPORT = True
-
-from astropy import wcs as fitswcs
-from astropy.modeling import CompoundModel
 from astropy.modeling.models import Scale, Identity
+from astropy import wcs as fitswcs
 
+try:
+    import gwcs
+    if LooseVersion(gwcs.__version__) > '0.12.0':
+        from gwcs.geometry import SphericalToCartesian
+        _GWCS_VER_GT_0P12 = True
+    else:
+        _GWCS_VER_GT_0P12 = False
+except ImportError:
+    _GWCS_VER_GT_0P12 = False
+
+import astropy
+if LooseVersion(astropy.__version__) >= '4.0':
+    _ASTROPY_VER_GE_4 = True
+    from astropy.modeling import CompoundModel
+else:
+    _ASTROPY_VER_GE_4 = False
 
 from tweakwcs.linearfit import build_fit_matrix
 from tweakwcs import tpwcs
@@ -30,6 +37,7 @@ from .helper_tpwcs import (make_mock_jwst_wcs, make_mock_jwst_pipeline,
 
 
 _ATOL = 1e3 * np.finfo(np.array([1.]).dtype).eps
+_NO_JWST_SUPPORT = not (_ASTROPY_VER_GE_4 and _GWCS_VER_GT_0P12)
 
 
 def test_tpwcs():

--- a/tweakwcs/tests/test_wcsutils.py
+++ b/tweakwcs/tests/test_wcsutils.py
@@ -10,18 +10,20 @@ from distutils.version import LooseVersion
 import numpy as np
 
 from tweakwcs import wcsutils
-import gwcs
-if LooseVersion(gwcs.__version__) > '0.12.0':
-    from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
-    _NO_JWST_SUPPORT = False
-    _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
-    _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
-else:
-    _NO_JWST_SUPPORT = True
 
+try:
+    import gwcs
+    if LooseVersion(gwcs.__version__) > '0.12.0':
+        from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
+        _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+        _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
+        _GWCS_VER_GT_0P12 = True
+    else:
+        _GWCS_VER_GT_0P12 = False
+except ImportError:
+    _GWCS_VER_GT_0P12 = False
 
-# _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
-# _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
+_NO_JWST_SUPPORT = not _GWCS_VER_GT_0P12
 
 
 @pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -18,9 +18,19 @@ import numpy as np
 from astropy import table
 from spherical_geometry.polygon import SphericalPolygon
 
-import gwcs
-if LooseVersion(gwcs.__version__) > '0.12.0':
-    from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
+try:
+    import gwcs
+    if LooseVersion(gwcs.__version__) > '0.12.0':
+        from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
+        _GWCS_VER_GT_0P12 = True
+    else:
+        _GWCS_VER_GT_0P12 = False
+
+except ImportError:
+    _GWCS_VER_GT_0P12 = False
+
+
+if _GWCS_VER_GT_0P12:
     _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
     _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 


### PR DESCRIPTION
This PR allows the use of the FITS WCS corrector with `astropy` versions >= 3.1 but less than 4.0 that is required for supporting JWST's WCS. `gwcs` package now is optional and required only if support for JWST's WCS is needed.