### PR TITLE
Support non-HST PC-based WCS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Release Notes
 0.6.0 (unreleased)
 ==================
 
+
+- Support FITS WCS that use ``PC`` matrix instead of the ``CD`` matrix
+  used in HSTs WCS. [#108]
+
 - Bug fix for alignment of multi-chip FITS images: correction of how
   transformations from the reference tangent plane are converted to
   individual images' tangent planes. [#106]

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -418,7 +418,10 @@ class FITSWCS(TPWCS):
         # initial approximation for CD matrix of the image WCS:
         (U, u) = self._linearize(orig_wcs, ref_tpwcs, wcs.wcs.crpix,
                                  matrix, shift, hx=hx, hy=hy)
-        wcs.wcs.cd = np.dot(wcs.wcs.cd, U).astype(np.double)
+        if hasattr(wcs.wcs, 'pc'):
+            wcs.wcs.pc = np.dot(wcs.wcs.pc, U).astype(np.double)
+        else:
+            wcs.wcs.cd = np.dot(wcs.wcs.cd, U).astype(np.double)
         wcs.wcs.set()
 
         # save linear transformation info to the meta attribute:


### PR DESCRIPTION
Detect `PC`-based non-HST WCS and correct `PC` matrix instead of the `CD` matrix.