### PR TITLE
Fix a possible crash when aligning FITS WCS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@ Release Notes
    ==================
 
 
-0.6.0 (unreleased)
-==================
+0.6.0 (25-February-2020)
+========================
 
 - Fix a possible crash when aligning FITS WCS images due to an unusual way
   ``stwcs.wcsutil.all_world2pix`` handles (or not) scalar arguments. [#110]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Release Notes
 0.6.0 (unreleased)
 ==================
 
+- Fix a possible crash when aligning FITS WCS images due to an unusual way
+  ``stwcs.wcsutil.all_world2pix`` handles (or not) scalar arguments. [#110]
+
 - Modified the angle at which the reported rotation angles are reported.
   Now rotation angles have the range ``[-180, 180]`` degrees. [#109]
 


### PR DESCRIPTION
Current code does not handle well WCS objects created with `stwcs.wcsutil.HSTWCS` due to how  `HSTWCS.all_world2pix()` does not handle scalar input arguments (unlike `astropy.wcs.WCS`). Special handling is required to deal with `HSTWCS`.