### PR TITLE
Compute TP to TP projection at the center of the pixel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,21 @@ Release Notes
    ==================
 
 
+0.6.2 (unreleased)
+==================
+
+- Adjust the point at which tangent plane-to-tangent plane transformation
+  is computed by 1/2 pixels for JWST corrections. This correction should
+  have no measurable impact on computed corrections. [#115]
+
+
 0.6.1 (09-March-2020)
 =====================
 
 - Fixed a bug in applying JWST correction for the case when alignment is
   performed twice on the same image. Due to this bug the inverse transformation
   was not updated. [#112]
+
 
 0.6.0 (25-February-2020)
 ========================

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -51,8 +51,8 @@ _ARCSEC2RAD = 1.0 / _RAD2ARCSEC
 
 
 def _tp2tp(tpwcs1, tpwcs2, s=None):
-    x = np.array([0.0, 1.0, 0.0], dtype=np.double)
-    y = np.array([0.0, 0.0, 1.0], dtype=np.double)
+    x = np.array([-0.5, 0.5, -0.5, 0.0], dtype=np.double)
+    y = np.array([-0.5, -0.5, 0.5, 0.0], dtype=np.double)
 
     if 'fit_info' in tpwcs1.meta:
         center = np.array(tpwcs1.meta['fit_info']['center'])
@@ -61,7 +61,7 @@ def _tp2tp(tpwcs1, tpwcs2, s=None):
 
     if s is None:
         xt, yt = tpwcs1.world_to_tanp(*tpwcs2.det_to_world(center[0] + x, center[1] + y))
-        m = np.array([(xt[1:] - xt[0]), (yt[1:] - yt[0])])
+        m = np.array([(xt[1:-1] - xt[0]), (yt[1:-1] - yt[0])])
         s = np.sqrt(np.fabs(np.linalg.det(m)))
 
     x *= s
@@ -72,8 +72,8 @@ def _tp2tp(tpwcs1, tpwcs2, s=None):
     xrp = np.array(xrp, np.longdouble)
     yrp = np.array(yrp, np.longdouble)
 
-    matrix = np.array([(xrp[1:] - xrp[0]), (yrp[1:] - yrp[0])]) / s
-    shift = np.array([xrp[0], yrp[0]])
+    matrix = np.array([(xrp[1:-1] - xrp[0]), (yrp[1:-1] - yrp[0])]) / s
+    shift = np.array([xrp[-1], yrp[-1]])
 
     return matrix, shift
 


### PR DESCRIPTION
Compute tangent plane-to-tangent plane projection for JWST transformations at the center of the given pixel instead at its border. The is no expected effect from this change or it should be practically undetectable.