### PR TITLE
Estimate scale of affine transform within bounding box limits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,11 @@ Release Notes
    ==================
 
 
-0.6.2 (unreleased)
-==================
+0.6.2 (07-April-2020)
+=====================
+
+- When WCS has valid bounding box, estimate scale at the center of the
+  bounding box. [#117]
 
 - Adjust the point at which tangent plane-to-tangent plane transformation
   is computed by 1/2 pixels for JWST corrections. This correction should

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -57,7 +57,13 @@ def _tp2tp(tpwcs1, tpwcs2, s=None):
     if 'fit_info' in tpwcs1.meta:
         center = np.array(tpwcs1.meta['fit_info']['center'])
     else:
-        center = np.zeros(2)
+        if tpwcs2.wcs.pixel_bounds is None:
+            # TODO: A pissible improvement would be to get an estimate
+            #       of "center" (where scale is estimated) from source
+            #       positions (if any).
+            center = np.zeros(2)
+        else:
+            center = np.mean(tpwcs2.wcs.pixel_bounds, axis=1)
 
     if s is None:
         xt, yt = tpwcs1.world_to_tanp(*tpwcs2.det_to_world(center[0] + x, center[1] + y))


### PR DESCRIPTION
Using `tweakwcs` version `0.6.1` in the `jwst` pipeline results in crash for MIRI images due to a scale of a linear transformation being evaluated at a location outside the bounding box of the WCS being aligned. This resulted in matrices filled with `nan`s.

CC: @jdavies-st @nden 