### PR TITLE
Detect when fit_info does not contain center

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Release Notes
 .. 0.7.0 (unreleased)
    ==================
 
+0.6.4 (unreleased)
+==================
+
+- Do not attempt to extract center of linear transformation when not available
+  in ``'fit_info'``. [#119]
+
 
 0.6.3 (14-April-2020)
 =====================

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -54,11 +54,11 @@ def _tp2tp(tpwcs1, tpwcs2, s=None):
     x = np.array([-0.5, 0.5, -0.5, 0.0], dtype=np.double)
     y = np.array([-0.5, -0.5, 0.5, 0.0], dtype=np.double)
 
-    if 'fit_info' in tpwcs1.meta:
+    if 'fit_info' in tpwcs1.meta and 'center' in tpwcs1.meta['fit_info']:
         center = np.array(tpwcs1.meta['fit_info']['center'])
     else:
         if tpwcs2.wcs.pixel_bounds is None:
-            # TODO: A pissible improvement would be to get an estimate
+            # TODO: A possible improvement would be to get an estimate
             #       of "center" (where scale is estimated) from source
             #       positions (if any).
             center = np.zeros(2)


### PR DESCRIPTION
Fixes a crash when `tweawcs` is run twice on the same set of images but one of the input images in the second run was used as a "regular" input image in the second run. The same error could also happen if in a previous run some of the images failed to be aligned.