### PR TITLE
Fix how multiple corrections are applied to JWST WCS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,12 @@ Release Notes
 .. 0.7.0 (unreleased)
    ==================
 
-0.6.4 (unreleased)
-==================
+
+0.6.4 (14-May-2020)
+===================
+
+- Fix a bug in how corrections are applied to a previously corrected
+  JWST WCS. [#120]
 
 - Do not attempt to extract center of linear transformation when not available
   in ``'fit_info'``. [#119]

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -151,7 +151,7 @@ def inv(m):
         invm[k, :] /= pv
         w = invm[k, :]
 
-        for l in range(k + 1, order):
+        for l in range(k + 1, order):  # noqa: E741
             pv2 = m[l, k]
             m[l, (k + 1):] -= pv2 * r
             m[l, k] = 0.0

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -871,28 +871,13 @@ class JWSTgWCS(TPWCS):
         else:
             # combine old and new corrections into a single one and replace
             # old transformation with the combined correction transformation:
-            v2ref, v3ref, roll = self._tpcorr['det_to_optic_axis'].angles.value
-
-            tpcorr2 = JWSTgWCS._tpcorr_init(
-                v2_ref=v2ref,
-                v3_ref=v3ref,
-                roll_ref=roll
-            )
-
             JWSTgWCS._tpcorr_combine_affines(
-                tpcorr2,
+                self._tpcorr,
                 matrix,
                 _ARCSEC2RAD * np.asarray(shift)
             )
 
-            JWSTgWCS._tpcorr_combine_affines(
-                tpcorr2,
-                self._tpcorr['tp_affine'].matrix.value,
-                self._tpcorr['tp_affine'].translation.value
-            )
-
-            self._tpcorr = tpcorr2
-            self._partial_tpcorr = JWSTgWCS._v2v3_to_tpcorr_from_full(tpcorr2)
+            self._partial_tpcorr = JWSTgWCS._v2v3_to_tpcorr_from_full(self._tpcorr)
 
             idx_v2v3 = frms.index(self._v23name)
             pipeline = deepcopy(self._wcs.pipeline)


### PR DESCRIPTION
The bug fixed in this PR resulted in incorrect application of subsequent corrections to a JWST WCS that already contained a tangent plane correction transformations resulting in misaligment of individual images in a previously aligned group of images.

Fixes https://github.com/spacetelescope/jwst/issues/4918