### PR TITLE
Bug fix: Unable to initialize JWSTgWCS from corrected WCS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Release Notes
 0.6.4 (14-May-2020)
 ===================
 
+- Bug fix: Unable to initialize ``JWSTgWCS`` tangent-plane corrector from an
+  already corrected WCS. [#122]
+
 - Fix a bug in how corrections are applied to a previously corrected
   JWST WCS. [#120]
 


### PR DESCRIPTION
The code for creating a `JWSTgWCS` corrector class from a previously corrected `gWCS` object crashes. The initialization fails due to the code being unable to extract _some_ submodels of a coumpound model.

This PR provides a temporary (or a permanent) solution until the issue is being investigated. 