### PR TITLE
Allow users to specify alignment tangent plane

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,21 @@ Release Notes
    ==================
 
 
+
+0.6.5 (unreleased)
+==================
+
+- Added ``ref_tpwcs`` parameter to ``imalign.fit_wcs()``,
+  ``imalign.align_wcs()``, ``wcsimage.WCSGroupCatalog.align_to_ref()`` to allow
+  alignment to be performed in user-specified distortion-free tangent
+  plane. [#125]
+
+- Renamed ``tanplane_wcs`` parameter in
+  ``wcsimage.WCSGroupCatalog.apply_affine_to_wcs()`` to ``ref_tpwcs``.
+  ``tanplane_wcs`` parameter was deprecated and will be removed in a future
+  release. [#125]
+
+
 0.6.4 (14-May-2020)
 ===================
 

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -38,12 +38,6 @@ jobs:
       condition: eq( variables['Agent.OS'], 'Windows_NT' )
       displayName: Pip on Windows
 
-      # Some namespace packages require but do not provide stsci.distutils.
-      # $(PIP_INSTALL) git+https://github.com/spacetelescope/jwst@stable
-    - script: |
-        $(PIP_INSTALL) pip numpy stsci.distutils d2to1
-      displayName: install dependencies
-
     - script: |
         $(PIP_INSTALL) -e .[test]
       displayName: build package

--- a/tweakwcs/tests/test_imalign.py
+++ b/tweakwcs/tests/test_imalign.py
@@ -245,7 +245,8 @@ def test_align_wcs_simple_twpwcs_ref(mock_fits_wcs):
     refcat = Table(xyr, names=('x', 'y'))
     tpwcs = FITSWCS(mock_fits_wcs, meta={'catalog': imcat})
     reftpwcs = FITSWCS(mock_fits_wcs, meta={'catalog': refcat})
-    status = align_wcs(tpwcs, reftpwcs, fitgeom='general', match=None)
+    status = align_wcs(tpwcs, reftpwcs, ref_tpwcs=tpwcs,
+                       fitgeom='general', match=None)
 
     assert status
     assert tpwcs.meta['fit_info']['status'] == 'SUCCESS'


### PR DESCRIPTION
This PR adds `ref_tpwcs` parameter to `imalign.fit_wcs()`, `imalign.align_wcs()`, `wcsimage.WCSGroupCatalog.align_to_ref()` to allow alignment to be performed in a user-specified distortion-free tangent plane.