### PR TITLE
Add rshift fitting mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,15 @@
 Release Notes
 =============
 
-.. 0.7.0 (unreleased)
+.. 0.7.1 (unreleased)
    ==================
 
+
+0.7.0 (unreleased)
+==================
+
+- Added ``linearfit.fit_rshift`` function to support a new ``fitgeom`` fitting
+  mode ``'rshift'`` that fits only for shifts and a rotation. [#128]
 
 
 0.6.5 (09-September-2020)

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -22,6 +22,7 @@ import astropy
 from . wcsimage import RefCatalog, WCSImageCatalog, WCSGroupCatalog
 from . tpwcs import TPWCS
 from . matchutils import TPMatch
+from . linearfit import SUPPORTED_FITGEOM_MODES, _SUPPORTED_FITGEOM_EN_STR
 
 from . import __version__
 
@@ -80,7 +81,7 @@ def fit_wcs(refcat, imcat, tpwcs, ref_tpwcs=None, fitgeom='general', nclip=3,
         defined. When not provided (i.e., set to `None`), reference tangent
         plane will be the same as defined by ``tpwcs`` argument.
 
-    fitgeom: {'shift', 'rscale', 'general'}, optional
+    fitgeom: {'shift', 'rshift', 'rscale', 'general'}, optional
         The fitting geometry to be used in fitting the matched object lists.
         This parameter is used in fitting the offsets, rotations and/or scale
         changes from the matched object lists. The 'general' fit geometry
@@ -235,9 +236,10 @@ def fit_wcs(refcat, imcat, tpwcs, ref_tpwcs=None, fitgeom='general', nclip=3,
 
     # check fitgeom:
     fitgeom = fitgeom.lower()
-    if fitgeom not in ['shift', 'rscale', 'general']:
-        raise ValueError("Unsupported 'fitgeom'. Valid values are: "
-                         "'shift', 'rscale', or 'general'")
+    if fitgeom not in SUPPORTED_FITGEOM_MODES:
+        raise ValueError(
+            f"Unsupported 'fitgeom'. Valid values are: {_SUPPORTED_FITGEOM_EN_STR:s}"
+        )
 
     wimcat = WCSImageCatalog(imcat, tpwcs,
                              name=imcat.meta.get('name', 'Unnamed'))
@@ -389,7 +391,7 @@ def align_wcs(wcscat, refcat=None, ref_tpwcs=None, enforce_user_order=True,
         ``'TPy'`` that represent the source coordinates in some common
         (to both catalogs) coordinate system.
 
-    fitgeom: {'shift', 'rscale', 'general'}, optional
+    fitgeom: {'shift', 'rshift', 'rscale', 'general'}, optional
         The fitting geometry to be used in fitting the matched object lists.
         This parameter is used in fitting the offsets, rotations and/or scale
         changes from the matched object lists. The 'general' fit geometry
@@ -521,17 +523,12 @@ def align_wcs(wcscat, refcat=None, ref_tpwcs=None, enforce_user_order=True,
 
     # check fitgeom:
     fitgeom = fitgeom.lower()
-    if fitgeom not in ['shift', 'rscale', 'general']:
-        raise ValueError("Unsupported 'fitgeom'. Valid values are: "
-                         "'shift', 'rscale', or 'general'")
-
-    if minobj is None:  # pragma: no branch
-        if fitgeom == 'general':
-            minobj = 3
-        elif fitgeom == 'rscale':
-            minobj = 2
-        else:
-            minobj = 1
+    try:
+        minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported 'fitgeom'. Valid values are: {_SUPPORTED_FITGEOM_EN_STR:s}"
+        )
 
     # process reference catalog or image if provided:
     if refcat is not None:

--- a/tweakwcs/tests/coveragerc
+++ b/tweakwcs/tests/coveragerc
@@ -1,0 +1,13 @@
+[run]
+source = tweakwcs
+omit =
+   tweakwcs/conftest*
+   tweakwcs/tests/*
+
+[report]
+exclude_lines =
+   # Have to re-enable the standard pragma
+   pragma: no cover
+
+   # Ignore branches that don't pertain to this version of Python
+   pragma: py{ignore_python_version}

--- a/tweakwcs/tests/test_imalign.py
+++ b/tweakwcs/tests/test_imalign.py
@@ -132,7 +132,7 @@ def test_fit_wcs_unsupported_fitgeom(mock_fits_wcs):
     with pytest.raises(ValueError) as e:
         tpwcs = fit_wcs(refcat, imcat, tpwcs, fitgeom='unsupported')
     assert (e.value.args[0] == "Unsupported 'fitgeom'. Valid values are: "
-            "'shift', 'rscale', or 'general'")
+            "'shift', 'rshift', 'rscale', or 'general'")
 
 
 @pytest.mark.parametrize('x, y, fitgeom', [
@@ -278,7 +278,7 @@ def test_align_wcs_unknown_fitgeom(mock_fits_wcs):
     with pytest.raises(ValueError) as e:
         align_wcs(tpwcs, fitgeom='unknown')
     assert (e.value.args[0] == "Unsupported 'fitgeom'. Valid values are: "
-            "'shift', 'rscale', or 'general'")
+            "'shift', 'rshift', 'rscale', or 'general'")
 
 
 def test_align_wcs_no_radec_in_refcat(mock_fits_wcs):

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -19,6 +19,8 @@ from astropy import table
 from astropy.utils.decorators import deprecated_renamed_argument
 from spherical_geometry.polygon import SphericalPolygon
 
+from . linearfit import SUPPORTED_FITGEOM_MODES
+
 try:
     import gwcs
     if LooseVersion(gwcs.__version__) > '0.12.0':
@@ -981,12 +983,12 @@ class WCSGroupCatalog(object):
         log.info("Computed '{:s}' fit for {}:".format(fitgeom, self.name))
         if fitgeom == 'shift':
             log.info("XSH: {:.6g}  YSH: {:.6g}".format(*fit['shift']))
-        elif fitgeom == 'rscale' and fit['proper']:
+        elif fitgeom in ['rshift', 'rscale'] and fit['proper']:
             log.info(
                 "XSH: {:.6g}  YSH: {:.6g}    ROT: {:.6g}    SCALE: {:.6g}"
                 .format(*fit['shift'], fit['proper_rot'], fit['<scale>'])
             )
-        elif fitgeom == 'general' or (fitgeom == 'rscale' and not
+        elif fitgeom == 'general' or (fitgeom in ['rshift', 'rscale'] and not
                                       fit['proper']):
             log.info("XSH: {:.6g}  YSH: {:.6g}    PROPER ROT: {:.6g}    "
                      .format(*fit['shift'], fit['proper_rot']))
@@ -1150,13 +1152,7 @@ class WCSGroupCatalog(object):
         for imcat in self:
             imcat.fit_status = "FAILED: Unknown error"
 
-        if minobj is None:
-            if fitgeom == 'general':
-                minobj = 3
-            elif fitgeom == 'rscale':
-                minobj = 2
-            else:
-                minobj = 1
+        minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
 
         if ref_tpwcs is None:
             ref_tpwcs = deepcopy(self._images[0].tpwcs)


### PR DESCRIPTION
This PR adds a new `'rshift'` fitting mode to the existing list of `fitgeom` modes. This will allow fitting only for shifts and rotations without fitting for scale.

CC: @stsci-hack 