### PR TITLE
Add support for JWST VA corrected V2V3 frames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@
 Release Notes
 =============
 
-.. 0.7.1 (unreleased)
+.. 0.7.2 (unreleased)
    ==================
+
+
+0.7.1 (16-February-2021)
+========================
+
+- Added support for detecting and using velocity aberration corrected
+  ``V2-V3`` frames when available in JWST WCS (``'v2v3vacorr'``). [#130]
 
 
 0.7.0 (11-November-2020)

--- a/tweakwcs/tests/test_matchutils.py
+++ b/tweakwcs/tests/test_matchutils.py
@@ -5,6 +5,7 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 from itertools import product
+import logging
 import random
 import pytest
 import numpy as np
@@ -222,8 +223,12 @@ def test_estimate_2dhist_shift_two_equal_maxima(caplog):
     imgxy = np.array([[0, 1], [0, 1]])
     refxy = np.array([[1, 0], [0, 2]])
     assert _estimate_2dhist_shift(imgxy, refxy, searchrad=3) == (-0.5, 0.0)
-    assert (caplog.record_tuples[-2][-1] == "Unable to estimate significance "
-            "of the detection of the initial shift.")
+    assert (caplog.record_tuples[-1][2] == "Found initial X and Y shifts of "
+            "-0.5, 0 with 4 matches." and
+            caplog.record_tuples[-1][1] == logging.INFO)
+    assert (caplog.record_tuples[-2][2] == "Unable to estimate significance "
+            "of the detection of the initial shift." and
+            caplog.record_tuples[-2][1] == logging.WARNING)
 
 
 @pytest.mark.parametrize('searchrad, separation, tolerance', [

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -579,7 +579,6 @@ class JWSTgWCS(TPWCS):
 
             This dictionary **must contain** the following keys and values:
 
-
             'v2_ref': float
                 V2 position of the reference point in arc seconds.
 
@@ -651,7 +650,7 @@ class JWSTgWCS(TPWCS):
             )
 
         else:
-            self._v23name = 'v2v3'
+            self._v23name = 'v2v3vacorr' if 'v2v3vacorr' in frms else 'v2v3'
             self._tpcorr = None
             self._default_tpcorr = JWSTgWCS._tpcorr_init(
                 v2_ref=v2_ref / 3600.0,
@@ -931,14 +930,23 @@ class JWSTgWCS(TPWCS):
             return (False, "First and last frames in the WCS pipeline must "
                     "be unique.")
 
-        if frms.count('v2v3') != 1:
-            return (False, "Only one 'v2v3' frame is allowed in the WCS "
-                    "pipeline.")
+        if frms.count('v2v3') != 1 or frms.count('v2v3vacorr') > 1:
+            return (False, "Only one 'v2v3' or 'v2v3vacorr' frame is allowed "
+                    "in the WCS pipeline.")
 
         idx_v2v3 = frms.index('v2v3')
         if idx_v2v3 == 0 or idx_v2v3 == (nframes - 1):
             return (False, "'v2v3' frame cannot be first or last in the WCS "
                     "pipeline.")
+
+        try:
+            idx_v2v3vacorr = frms.index('v2v3vacorr')
+            if idx_v2v3vacorr < idx_v2v3 or idx_v2v3vacorr == (nframes - 1):
+                return (False, "'v2v3vacorr' frame cannot precede the 'v2v3' "
+                        "frame or be the last frame in the WCS pipeline.")
+            idx_v2v3 = idx_v2v3vacorr
+        except ValueError:
+            pass
 
         nv2v3corr = frms.count('v2v3corr')
         if nv2v3corr == 0:


### PR DESCRIPTION
This PR adds support for JWST VA-corrected `v2v3` WCS frames called `v2v3vacorr`. When present, WCS "tweaking" will be performed on VA-corrected frame and when it is not present in the WCS's pipeline, the original `v2v3` frame will be used.

A new release of `tweakwcs` is necessary before https://github.com/spacetelescope/jwst/pull/5602 can be merged.