### PR TITLE
Fix deprecation warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
 
 - job: 'PEP8'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
 
   steps:
   - task: UsePythonVersion@0
@@ -44,7 +44,7 @@ jobs:
 - job: 'Publish'
   dependsOn: 'Linux'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
 
   steps:
   - task: UsePythonVersion@0

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -2,11 +2,11 @@ jobs:
 - job: ${{ format(parameters.name) }}
   pool:
     ${{ if eq(parameters.os, 'windows') }}:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
     ${{ if eq(parameters.os, 'macos') }}:
       vmImage: macOS-10.15
     ${{ if eq(parameters.os, 'linux') }}:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
 
   strategy:
     matrix:
@@ -14,10 +14,10 @@ jobs:
       # py35 is mostly dead at this point anyway
       #Python35:
       #  python.version: '3.5'
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -108,7 +108,7 @@ def inv(m):
     order = m.shape[0]
 
     # create permutation matrices:
-    qt = np.eye(order, dtype=np.int)
+    qt = np.eye(order, dtype=int)
 
     eps = np.finfo(np.double).tiny
 
@@ -131,7 +131,7 @@ def inv(m):
 
         if im != k or jm != k:
             # swap rows & columns:
-            q = np.eye(order, dtype=np.int)
+            q = np.eye(order, dtype=int)
 
             # swap rows in the m and invm matrix:
             m[k, :], m[im, :] = m[im, :], m[k, :].copy()

--- a/tweakwcs/linearfit.py
+++ b/tweakwcs/linearfit.py
@@ -412,7 +412,7 @@ def fit_shifts(xy, uv, wxy=None, wuv=None):
         if np.any(w < 0.0):
             raise ValueError("Invalid weights: weights must be non-negative.")
 
-        if not np.sum(w > 0, dtype=np.int):
+        if not np.sum(w > 0, dtype=int):
             raise ValueError("Not enough valid data for 'shift' fit: "
                              "too many weights are zero!")
 

--- a/tweakwcs/tests/test_linearfit.py
+++ b/tweakwcs/tests/test_linearfit.py
@@ -119,8 +119,8 @@ def weight_data(request):
     if not any(request.param):
         wxy = None
         wuv = None
-        idx_xy = (np.array([], dtype=np.int), )
-        idx_uv = (np.array([], dtype=np.int), )
+        idx_xy = (np.array([], dtype=int), )
+        idx_uv = (np.array([], dtype=int), )
         bd_xy = np.zeros((0, 2))
         bd_uv = np.zeros((0, 2))
 
@@ -149,7 +149,7 @@ def weight_data(request):
         idx = np.random.choice(np.arange(_LARGE_SAMPLE_SIZE),
                                nbd, replace=False)
         idx_xy = (idx, )
-        idx_uv = (np.array([], dtype=np.int), )
+        idx_uv = (np.array([], dtype=int), )
         wxy = np.random.random(_LARGE_SAMPLE_SIZE)
         wxy[idx_xy] = 0.0
         wuv = None
@@ -161,7 +161,7 @@ def weight_data(request):
         idx = np.random.choice(np.arange(_LARGE_SAMPLE_SIZE), nbd,
                                replace=False)
         idx_uv = (idx, )
-        idx_xy = (np.array([], dtype=np.int), )
+        idx_xy = (np.array([], dtype=int), )
         wuv = np.random.random(_LARGE_SAMPLE_SIZE)
         wuv[idx_uv] = 0.0
         wxy = None
@@ -409,10 +409,10 @@ def test_iter_linear_fit_clip_style(ideal_large_data, weight_data,
     assert fit['proper'] == proper
     if nclip:
         assert fit['eff_nclip'] > 0
-        assert fit['fitmask'].sum(dtype=np.int) < npts
+        assert fit['fitmask'].sum(dtype=int) < npts
     else:
         assert fit['eff_nclip'] == 0
-        assert (fit['fitmask'].sum(dtype=np.int) == npts -
+        assert (fit['fitmask'].sum(dtype=int) == npts -
                 np.union1d(idx_xy[0], idx_uv[0]).size)
 
 

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -181,7 +181,7 @@ def test_jwst_wcs_corr_are_being_combined(mock_jwst_wcs):
 
     assert len(v2v3idx) == 1
 
-    tp_corr = wc.wcs.pipeline[v2v3idx[0] - 1][1]
+    tp_corr = wc.wcs.pipeline[v2v3idx[0] - 1].transform
 
     assert isinstance(tp_corr, CompoundModel)
     assert np.max(np.abs(tp_corr['tp_affine'].matrix.value - np.identity(2))) < _ATOL

--- a/tweakwcs/tests/test_wcsimage.py
+++ b/tweakwcs/tests/test_wcsimage.py
@@ -36,7 +36,7 @@ def rect_imcat(mock_fits_wcs):
 
 @pytest.mark.parametrize('val, expected', [
     (1, True), (1.0, False), ('1', False), (True, False),
-    (np.bool(1), False), (np.float16(1.0), False), (np.int16(1), True),
+    (np.bool_(1), False), (np.float16(1.0), False), (np.int16(1), True),
 ])
 def test_is_int(val, expected):
     assert _is_int(val) is expected
@@ -297,8 +297,8 @@ def test_wcsgroupcat_match2ref(mock_fits_wcs, rect_imcat):
 
     ref.calc_tanp_xy(rect_imcat.tpwcs)
     g.calc_tanp_xy(rect_imcat.tpwcs)
-    g.catalog['matched_ref_id'] = np.ones(5, dtype=np.bool)
-    g.catalog['_raw_matched_ref_idx'] = np.ones(5, dtype=np.bool)
+    g.catalog['matched_ref_id'] = np.ones(5, dtype=bool)
+    g.catalog['_raw_matched_ref_idx'] = np.ones(5, dtype=bool)
     g.match2ref(ref, match=TPMatch())
 
 

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -625,7 +625,7 @@ class JWSTgWCS(TPWCS):
         if 'v2v3corr' in frms:
             self._v23name = 'v2v3corr'
             self._tpcorr = deepcopy(
-                wcs.pipeline[frms.index('v2v3corr') - 1][1]
+                wcs.pipeline[frms.index('v2v3corr') - 1].transform
             )
             self._default_tpcorr = None
             if not JWSTgWCS._check_tpcorr_structure(self._tpcorr):
@@ -673,8 +673,8 @@ class JWSTgWCS(TPWCS):
     def _update_transformations(self):
         # define transformations from detector/world coordinates to
         # the tangent plane:
-        detname = self._wcs.pipeline[0][0].name
-        worldname = self._wcs.pipeline[-1][0].name
+        detname = self._wcs.pipeline[0].frame.name
+        worldname = self._wcs.pipeline[-1].frame.name
 
         # Generally needed transformations:
         self._world_to_v23 = self._wcs.get_transform(worldname, self._v23name)
@@ -905,7 +905,7 @@ class JWSTgWCS(TPWCS):
 
             idx_v2v3 = frms.index(self._v23name)
             pipeline = deepcopy(self._wcs.pipeline)
-            pipeline[idx_v2v3 - 1] = (pipeline[idx_v2v3 - 1][0],
+            pipeline[idx_v2v3 - 1] = (pipeline[idx_v2v3 - 1].frame,
                                       deepcopy(self._tpcorr))
             self._wcs = gwcs.WCS(pipeline, name=self._owcs.name)
 

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -691,7 +691,7 @@ class WCSGroupCatalog(object):
 
             col_catname = table.MaskedColumn([catname], name='cat_name')
             col_catname = col_catname[[False]]
-            col_imcatidx = table.MaskedColumn([], dtype=np.int,
+            col_imcatidx = table.MaskedColumn([], dtype=int,
                                               name='_imcat_idx')
             col_id = table.MaskedColumn(image.catalog['id'])
             col_x = table.MaskedColumn([], name='x', dtype=np.double)


### PR DESCRIPTION
Fix deprecation warnings due to `numpy` types and `gwcs`'s pipeline access issues.

Fixes #127