### PR TITLE
Make code more robust to exceptions in the spherical geometry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ INSTALL_REQUIRES = [
     'astropy>=3.1',
     'stsci.stimage',
     'stsci.imagestats',
-    'spherical_geometry',
+    'spherical_geometry>=1.2.20',
 ]
 
 TESTS_REQUIRE = [

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -699,7 +699,7 @@ def overlap_matrix(images):
     m = np.zeros((nimg, nimg), dtype=np.double)
     for i in range(nimg):
         for j in range(i + 1, nimg):
-            area = images[i].intersection_area(images[j])
+            area = images[i]._guarded_intersection_area(images[j])
             m[j, i] = area
             m[i, j] = area
     return m

--- a/tweakwcs/tests/test_wcsimage.py
+++ b/tweakwcs/tests/test_wcsimage.py
@@ -98,6 +98,13 @@ def test_wcsimcat_intersections(mock_fits_wcs, rect_imcat):
     )
 
 
+def test_wcsimcat_guarded_intersection_area(mock_fits_wcs, rect_imcat):
+    assert np.allclose(
+        rect_imcat._guarded_intersection_area(rect_imcat),
+        2.9904967391303217e-12, atol=0.0, rtol=5.0e-4
+    )
+
+
 def test_wcsimcat_no_wcs_bb(mock_fits_wcs, rect_cat):
     tpwcs = FITSWCS(mock_fits_wcs)
     tpwcs._owcs.pixel_bounds = None
@@ -194,6 +201,14 @@ def test_wcsgroupcat_intersections(mock_fits_wcs, rect_imcat):
 
     assert np.allclose(
         g.intersection_area(g), 2.9904967391303217e-12, atol=0.0, rtol=5.0e-4
+    )
+
+
+def test_wcsgroupcat_guarded_intersection_area(mock_fits_wcs, rect_imcat):
+    g = WCSGroupCatalog(rect_imcat)
+    assert np.allclose(
+        g._guarded_intersection_area(g), 2.9904967391303217e-12,
+        atol=0.0, rtol=5.0e-4
     )
 
 
@@ -360,6 +375,19 @@ def test_wcsrefcat_intersections(mock_fits_wcs, rect_imcat):
 
     assert np.allclose(
         ref.intersection_area(ref), 2.9902125220360176e-10, atol=0.0,
+        rtol=0.005,
+    )
+
+
+def test_wcsrefcat_guarded_intersection_area(mock_fits_wcs, rect_imcat):
+    ra, dec = mock_fits_wcs.all_pix2world(10 * rect_imcat.catalog['x'],
+                                          10 * rect_imcat.catalog['y'], 0)
+    refcat = Table([ra, dec], names=('RA', 'DEC'))
+    ref = RefCatalog(refcat)
+    ref.calc_tanp_xy(rect_imcat.tpwcs)
+
+    assert np.allclose(
+        ref._guarded_intersection_area(ref), 2.9902125220360176e-10, atol=0.0,
         rtol=0.005,
     )
 


### PR DESCRIPTION
This PR will attempt to catch `spherical_geometry` exceptions and fall back to some less accurate but (hopefully) acceptable alternative handling.

Fixes #134 and many other similar issues in the `JWST` pipeline (hopefully):
Fixes https://github.com/spacetelescope/jwst/issues/4601
Fixes https://github.com/spacetelescope/jwst/issues/3764