### PR TITLE
Do not override user provided value for minobj

### DIFF
--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -1196,7 +1196,10 @@ class WCSGroupCatalog(object):
         for imcat in self:
             imcat.fit_status = "FAILED: Unknown error"
 
-        minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+        if minobj is None:
+            minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+
+        log.debug("minobj set to {} for fitgeom='{}'".format(minobj, fitgeom))
 
         if ref_tpwcs is None:
             ref_tpwcs = deepcopy(self._images[0].tpwcs)


### PR DESCRIPTION
This simple change re-enables the ability for the user to specify the desired minimum number of objects to use in fitting the data.  The code had a hard-coded value which completely ignored this user input.  

In addition, a log message will get reported in DEBUG mode to record what value gets used for the fit.  