### PR TITLE
Trap bad fits of 2dhist peak

### DIFF
--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -517,7 +517,10 @@ def _find_peak(data, peak_fit_box=5, mask=None):
     xm = (c01 * c11 - 2.0 * c02 * c10) / det
     ym = (c10 * c11 - 2.0 * c01 * c20) / det
 
-    if 0.0 <= xm <= (nx - 1.0) and 0.0 <= ym <= (ny - 1.0):
+    if xm < x1 or xm > x2 or ym < y1 or ym > y2:
+        xm, ym = coord
+        fit_status = 'WARNING: BADFIT'
+    elif 0.0 <= xm <= (nx - 1.0) and 0.0 <= ym <= (ny - 1.0):
         fit_status = 'SUCCESS'
     else:
         xm = 0.0 if xm < 0.0 else min(xm, nx - 1.0)


### PR DESCRIPTION
Linear LSQ fitting of the peak in the 2d histogram can end up returning peak values WELL outside the extraction box for the peak.  The current code does not recognize those cases resulting in what it reports as a GOOD FIT while introducing severe mis-alignment of the data as evidenced by alignment of `ieie02010` (seen in [the HST archive previews](https://archive.stsci.edu/cgi-bin/mastpreview?mission=hst&dataid=IEIE02010)).  

This PR traps cases where the fit to the peak results in a position well outside the extraction box around the actual max value, and simply resets the peak value to the position of the max value.  This will allow subsequent cross-matching to succeed without introducing any errors in the alignment. 