### PR TITLE
Do not ignore user-provided minobj parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,11 @@ Release Notes
    ==================
 
 
-0.7.3 (unreleased)
-==================
+0.7.3 (12-August-2021)
+======================
+
+- Fix a bug due to which ``minobj`` parameter to
+  ``WCSGroupCatalog.align_to_ref()`` and ``align_wcs()`` was ignored. [#144]
 
 - Make peak finding code switch to center-of-mass algorithm when estimated
   2D parabolic fit estimates a peak outside of the fit box. Reduce

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -524,7 +524,9 @@ def align_wcs(wcscat, refcat=None, ref_tpwcs=None, enforce_user_order=True,
     # check fitgeom:
     fitgeom = fitgeom.lower()
     try:
-        minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+        if minobj is None:
+            minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+            log.debug(f"Setting 'minobj' to {minobj} for fitgeom='{fitgeom}'")
     except KeyError:
         raise ValueError(
             f"Unsupported 'fitgeom'. Valid values are: {_SUPPORTED_FITGEOM_EN_STR:s}"

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -1196,7 +1196,9 @@ class WCSGroupCatalog(object):
         for imcat in self:
             imcat.fit_status = "FAILED: Unknown error"
 
-        minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+        if minobj is None:
+            minobj = SUPPORTED_FITGEOM_MODES[fitgeom]
+            log.debug(f"Setting 'minobj' to {minobj} for fitgeom='{fitgeom}'")
 
         if ref_tpwcs is None:
             ref_tpwcs = deepcopy(self._images[0].tpwcs)


### PR DESCRIPTION
As reported in https://github.com/spacetelescope/tweakwcs/pull/141 user-provided `minobj` parameter is ignored in calls to ``WCSGroupCatalog.align_to_ref()`` and ``align_wcs()``. This PR replaces #141 by implementing almost identical fix as proposed in #141 plus a changelog entry and a unit test. Also, the debug logging message is issued only when user does not provide a `minobj` value.

Closes #141