### PR TITLE
Remove duplicate points from convex hull

### DIFF
--- a/tweakwcs/tests/test_wcsimage.py
+++ b/tweakwcs/tests/test_wcsimage.py
@@ -8,7 +8,6 @@ import copy
 import pytest
 import numpy as np
 from astropy.table import Table, Column
-from spherical_geometry.polygon import SphericalPolygon
 from tweakwcs import TPMatch, FITSWCS
 from tweakwcs.wcsimage import (convex_hull, RefCatalog, WCSImageCatalog,
                                WCSGroupCatalog, _is_int)

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -463,7 +463,7 @@ class WCSImageCatalog(object):
             # Remove any duplicate points at this stage
             # This will prevent any mathematical singularities with the Polygon
             # or the computation of it's area.
-            _,idx = np.unique(ra, return_index=True)
+            _, idx = np.unique(ra, return_index=True)
             ra = ra[np.sort(idx)]
             dec = dec[np.sort(idx)]
             # else, for len(x) in [1, 2], use entire image footprint.
@@ -474,8 +474,8 @@ class WCSImageCatalog(object):
             #       dec[0] != dec[-1] (even though we close the polygon in the
             #       previous two lines). Then SphericalPolygon fails because
             #       points are not closed. Threfore we force it to be closed:
-            ra[-1] = ra[0]
-            dec[-1] = dec[0]
+            ra = np.append(ra, ra[0])
+            dec = np.append(dec, dec[0])
 
             self._bb_radec = (ra, dec)
             self._polygon = SphericalPolygon.from_radec(ra, dec)

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -460,6 +460,12 @@ class WCSImageCatalog(object):
 
         elif len(x) > 2:
             ra, dec = convex_hull(x, y, wcs=self.det_to_world)
+            # Remove any duplicate points at this stage
+            # This will prevent any mathematical singularities with the Polygon
+            # or the computation of it's area.
+            _,idx = np.unique(ra, return_index=True)
+            ra = ra[np.sort(idx)]
+            dec = dec[np.sort(idx)]
             # else, for len(x) in [1, 2], use entire image footprint.
             # TODO: a more robust algorithm should be implemented to deal with
             #       len(x) in [1, 2] cases.


### PR DESCRIPTION
This simple update removes any duplicate points determined when computing the convex hull of a SphericalPolygon which happens on occasion.  These duplicate entries in the points describing the convex hull can trigger a ValueError Exception in the acos function when computing the area of the SphericalPolygon created from the list of RA, Dec hull positions.  These changes do not alter the logic for computing the convex hull points, rather it merely insures that the set of points for the convex hull is unique. 

The original problem was found when using this code to align 'j8mbztcnq' with 'drizzlepac.align.perform_align()'.