### PR TITLE
Add Python 3.9 and 3.10 to CI testing matrix

### DIFF
--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -18,6 +18,10 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
     maxParallel: 4
 
   steps:


### PR DESCRIPTION
Add Python 3.9 and 3.10 to CI testing matrix.