### PR TITLE
Replace deprecated code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ INSTALL_REQUIRES = [
     'stsci.stimage',
     'stsci.imagestats',
     'spherical_geometry>=1.2.20',
-    'packaging>=19.0",
+    'packaging>=19.0',
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ INSTALL_REQUIRES = [
     'stsci.stimage',
     'stsci.imagestats',
     'spherical_geometry>=1.2.20',
+    'packaging>=19.0",
 ]
 
 TESTS_REQUIRE = [

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -11,14 +11,14 @@ of ``WCS``.
 import logging
 from copy import deepcopy
 from abc import ABC, abstractmethod
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 import astropy
 
 try:
     import gwcs
-    if LooseVersion(gwcs.__version__) > '0.12.0':
+    if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
         _GWCS_VER_GT_0P12 = True
     else:
@@ -26,7 +26,7 @@ try:
 except ImportError:
     _GWCS_VER_GT_0P12 = False
 
-if LooseVersion(astropy.__version__) >= '4.0':
+if Version(astropy.__version__) >= Version('4.0'):
     _ASTROPY_VER_GE_4 = True
     from astropy.modeling import CompoundModel
     from astropy.modeling.models import (

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -12,7 +12,7 @@ import os
 import logging
 import numbers
 from copy import deepcopy
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 from astropy import table
@@ -23,7 +23,7 @@ from . linearfit import SUPPORTED_FITGEOM_MODES
 
 try:
     import gwcs
-    if LooseVersion(gwcs.__version__) > '0.12.0':
+    if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
         _GWCS_VER_GT_0P12 = True
     else:


### PR DESCRIPTION
`distutils.LooseVersion` is deprecated. The recommended way to check the version now is using `packaging`.