### PR TITLE
Fix deprecation warnings for using disutils LooseVersion

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ import sys
 import datetime
 import sphinx
 import stsci_rtd_theme
-from distutils.version import LooseVersion
+from packaging.version import Version
 try:
     from ConfigParser import ConfigParser
 except ImportError:
@@ -44,8 +44,8 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
 def check_sphinx_version(expected_version):
-    sphinx_version = LooseVersion(sphinx.__version__)
-    expected_version = LooseVersion(expected_version)
+    sphinx_version = Version(sphinx.__version__)
+    expected_version = Version(expected_version)
     if sphinx_version < expected_version:
         raise RuntimeError(
             "At least Sphinx version {0} is required to build this "
@@ -84,7 +84,7 @@ extensions = [
 if on_rtd:
     extensions.append('sphinx.ext.mathjax')
 
-elif LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
+elif Version(sphinx.__version__) < Version('1.4'):
     extensions.append('sphinx.ext.pngmath')
 
 else:

--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -5,8 +5,7 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import math
-from distutils.version import LooseVersion
-
+from packaging.version import Version
 import numpy as np
 from astropy.modeling import Model, Parameter
 from astropy.modeling.models import AffineTransformation2D, Identity
@@ -15,7 +14,7 @@ from astropy import units as u
 
 try:
     import gwcs
-    if LooseVersion(gwcs.__version__) > '0.12.0':
+    if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
         _GWCS_VER_GT_0P12 = True
     else:

--- a/tweakwcs/tests/test_multichip_jwst.py
+++ b/tweakwcs/tests/test_multichip_jwst.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 import numpy as np
@@ -20,7 +20,7 @@ import tweakwcs
 
 try:
     import gwcs
-    if LooseVersion(gwcs.__version__) > '0.12.0':
+    if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
         from gwcs import coordinate_frames as cf
         _GWCS_VER_GT_0P12 = True
@@ -29,7 +29,7 @@ try:
 except ImportError:
     _GWCS_VER_GT_0P12 = False
 
-_ASTROPY_VER_GE_4 = LooseVersion(astropy.__version__) >= '4.0'
+_ASTROPY_VER_GE_4 = Version(astropy.__version__) >= Version('4.0')
 _NO_JWST_SUPPORT = not (_ASTROPY_VER_GE_4 and _GWCS_VER_GT_0P12)
 
 _ATOL = 1e3 * np.finfo(np.array([1.]).dtype).eps

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -6,7 +6,7 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 import copy
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 from astropy.modeling.models import Scale, Identity
@@ -14,7 +14,7 @@ from astropy import wcs as fitswcs
 
 try:
     import gwcs
-    if LooseVersion(gwcs.__version__) > '0.12.0':
+    if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import SphericalToCartesian
         _GWCS_VER_GT_0P12 = True
     else:
@@ -23,7 +23,7 @@ except ImportError:
     _GWCS_VER_GT_0P12 = False
 
 import astropy
-if LooseVersion(astropy.__version__) >= '4.0':
+if Version(astropy.__version__) >= Version('4.0'):
     _ASTROPY_VER_GE_4 = True
     from astropy.modeling import CompoundModel
 else:

--- a/tweakwcs/tests/test_wcsutils.py
+++ b/tweakwcs/tests/test_wcsutils.py
@@ -5,7 +5,7 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 
@@ -13,7 +13,7 @@ from tweakwcs import wcsutils
 
 try:
     import gwcs
-    if LooseVersion(gwcs.__version__) > '0.12.0':
+    if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
         _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
         _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)


### PR DESCRIPTION
This PR uses `packaging.version` instead of `distutils`' `LooseVersion` to avoid numerous deprecation warnings.