### PR TITLE
Fix deprecation warnings when indexing gwcs pipeline steps

### DIFF
--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -220,7 +220,7 @@ def test_jwstgwcs_wrong_tpcorr_type(mock_jwst_wcs):
     wc.set_correction()
     p = wc.wcs.pipeline
 
-    np = [(v[0], create_V2V3ToDet()) if v[0].name == 'v2v3vacorr'
+    np = [(v.frame, create_V2V3ToDet()) if v.frame.name == 'v2v3vacorr'
           else v for v in p]
     mangled_wc = gwcs.wcs.WCS(np)
 

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -886,7 +886,9 @@ class JWSTgWCS(TPWCS):
 
             idx_v2v3 = frms.index(self._v23name)
             pipeline = deepcopy(self._wcs.pipeline)
-            pf, pt = pipeline[idx_v2v3]
+            step = pipeline[idx_v2v3]
+            pf = step.frame
+            pt = step.transform
             pipeline[idx_v2v3] = (pf, deepcopy(self._tpcorr))
             frm_v2v3corr = deepcopy(pf)
             frm_v2v3corr.name = 'v2v3corr'


### PR DESCRIPTION
Quiet deprecation warnings from `gwcs`:

```python
wcs.py:2947: DeprecationWarning: Indexing a WCS.pipeline step is deprecated. Use the `frame` and `transform` attributes instead.
```