### PR TITLE
Remove tests for astropy versions GT 4.0

### DIFF
--- a/tweakwcs/tests/test_multichip_jwst.py
+++ b/tweakwcs/tests/test_multichip_jwst.py
@@ -2,7 +2,6 @@ from packaging.version import Version
 
 import pytest
 import numpy as np
-import astropy
 from astropy.io import fits
 from astropy import table
 from astropy import wcs as fitswcs
@@ -23,14 +22,11 @@ try:
     if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
         from gwcs import coordinate_frames as cf
-        _GWCS_VER_GT_0P12 = True
+        _NO_JWST_SUPPORT = False
     else:
-        _GWCS_VER_GT_0P12 = False
+        _NO_JWST_SUPPORT = True
 except ImportError:
-    _GWCS_VER_GT_0P12 = False
-
-_ASTROPY_VER_GE_4 = Version(astropy.__version__) >= Version('4.0')
-_NO_JWST_SUPPORT = not (_ASTROPY_VER_GE_4 and _GWCS_VER_GT_0P12)
+    _NO_JWST_SUPPORT = True
 
 _ATOL = 1e3 * np.finfo(np.array([1.]).dtype).eps
 

--- a/tweakwcs/tests/test_tpwcs.py
+++ b/tweakwcs/tests/test_tpwcs.py
@@ -16,18 +16,13 @@ try:
     import gwcs
     if Version(gwcs.__version__) > Version('0.12.0'):
         from gwcs.geometry import SphericalToCartesian
-        _GWCS_VER_GT_0P12 = True
+        _NO_JWST_SUPPORT = False
     else:
-        _GWCS_VER_GT_0P12 = False
+        _NO_JWST_SUPPORT = True
 except ImportError:
-    _GWCS_VER_GT_0P12 = False
+    _NO_JWST_SUPPORT = True
 
-import astropy
-if Version(astropy.__version__) >= Version('4.0'):
-    _ASTROPY_VER_GE_4 = True
-    from astropy.modeling import CompoundModel
-else:
-    _ASTROPY_VER_GE_4 = False
+from astropy.modeling import CompoundModel
 
 from tweakwcs.linearfit import build_fit_matrix
 from tweakwcs import tpwcs
@@ -37,7 +32,6 @@ from .helper_tpwcs import (make_mock_jwst_wcs, make_mock_jwst_pipeline,
 
 
 _ATOL = 100 * np.finfo(np.array([1.]).dtype).eps
-_NO_JWST_SUPPORT = not (_ASTROPY_VER_GE_4 and _GWCS_VER_GT_0P12)
 
 
 def test_tpwcs():

--- a/tweakwcs/tests/test_wcsutils.py
+++ b/tweakwcs/tests/test_wcsutils.py
@@ -17,13 +17,11 @@ try:
         from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
         _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
         _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
-        _GWCS_VER_GT_0P12 = True
+        _NO_JWST_SUPPORT = False
     else:
-        _GWCS_VER_GT_0P12 = False
+        _NO_JWST_SUPPORT = True
 except ImportError:
-    _GWCS_VER_GT_0P12 = False
-
-_NO_JWST_SUPPORT = not _GWCS_VER_GT_0P12
+    _NO_JWST_SUPPORT = True
 
 
 @pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -14,7 +14,6 @@ from abc import ABC, abstractmethod
 from packaging.version import Version
 
 import numpy as np
-import astropy
 
 try:
     import gwcs
@@ -26,15 +25,11 @@ try:
 except ImportError:
     _GWCS_VER_GT_0P12 = False
 
-if Version(astropy.__version__) >= Version('4.0'):
-    _ASTROPY_VER_GE_4 = True
-    from astropy.modeling import CompoundModel
-    from astropy.modeling.models import (
-        AffineTransformation2D, Scale, Identity, Mapping, Const1D,
-        RotationSequence3D
-    )
-else:
-    _ASTROPY_VER_GE_4 = False
+from astropy.modeling import CompoundModel
+from astropy.modeling.models import (
+    AffineTransformation2D, Scale, Identity, Mapping, Const1D,
+    RotationSequence3D
+)
 
 from .linalg import inv
 from . import __version__  # noqa: F401
@@ -594,11 +589,6 @@ class JWSTgWCS(TPWCS):
             Dictionary that will be merged to the object's ``meta`` fields.
 
         """
-        if not _ASTROPY_VER_GE_4:
-            raise NotImplementedError(
-                "JWST support requires astropy version >= 4.0"
-            )
-
         if not _GWCS_VER_GT_0P12:
             raise NotImplementedError(
                 "JWST support requires gwcs version > 0.12.0 "


### PR DESCRIPTION
Since https://github.com/spacetelescope/tweakwcs/pull/153 these checks for `astropy` version `> 4.0` are not necessary.