### PR TITLE
Set minimum gwcs version to 0.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ PACKAGE_DATA = {
 INSTALL_REQUIRES = [
     'numpy',
     'astropy>=5.0.4',
+    'gwcs>=0.14.0',
     'stsci.stimage',
     'stsci.imagestats',
     'spherical_geometry>=1.2.20',

--- a/tweakwcs/tests/helper_tpwcs.py
+++ b/tweakwcs/tests/helper_tpwcs.py
@@ -5,45 +5,18 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import math
-from packaging.version import Version
 import numpy as np
 from astropy.modeling import Model, Parameter
 from astropy.modeling.models import AffineTransformation2D, Identity
 from astropy import coordinates as coord
 from astropy import units as u
-
-try:
-    import gwcs
-    if Version(gwcs.__version__) > Version('0.12.0'):
-        from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
-        _GWCS_VER_GT_0P12 = True
-    else:
-        _GWCS_VER_GT_0P12 = False
-except (ImportError, ModuleNotFoundError):
-    _GWCS_VER_GT_0P12 = False
-
-if _GWCS_VER_GT_0P12:
-    _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
-    _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
-
-else:
-    def _S2C(phi, theta):
-        phi = np.deg2rad(phi)
-        theta = np.deg2rad(theta)
-        cs = np.cos(theta)
-        x = cs * np.cos(phi)
-        y = cs * np.sin(phi)
-        z = np.sin(theta)
-        return x, y, z
-
-    def _C2S(x, y, z):
-        h = np.hypot(x, y)
-        phi = np.rad2deg(np.arctan2(y, x))
-        theta = np.rad2deg(np.arctan2(z, h))
-        return phi, theta
-
-
+import gwcs
+from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
 from tweakwcs.tpwcs import TPWCS, JWSTgWCS
+
+
+_S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+_C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
 
 class DummyTPWCS(TPWCS):

--- a/tweakwcs/tests/test_multichip_jwst.py
+++ b/tweakwcs/tests/test_multichip_jwst.py
@@ -1,6 +1,3 @@
-from packaging.version import Version
-
-import pytest
 import numpy as np
 from astropy.io import fits
 from astropy import table
@@ -13,20 +10,11 @@ from astropy.modeling.models import (
 )
 from astropy import units as u
 from astropy import coordinates as coord
-
+import gwcs
+from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
+from gwcs import coordinate_frames as cf
 import tweakwcs
 
-
-try:
-    import gwcs
-    if Version(gwcs.__version__) > Version('0.12.0'):
-        from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
-        from gwcs import coordinate_frames as cf
-        _NO_JWST_SUPPORT = False
-    else:
-        _NO_JWST_SUPPORT = True
-except ImportError:
-    _NO_JWST_SUPPORT = True
 
 _ATOL = 1e3 * np.finfo(np.array([1.]).dtype).eps
 
@@ -137,7 +125,6 @@ def _match(x, y):
     return match
 
 
-@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_multichip_jwst_alignment():
     w1 = _make_gwcs_wcs('data/wfc3_uvis1.hdr')
 

--- a/tweakwcs/tests/test_wcsutils.py
+++ b/tweakwcs/tests/test_wcsutils.py
@@ -5,26 +5,15 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import pytest
-from packaging.version import Version
 
 import numpy as np
-
+from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
 from tweakwcs import wcsutils
 
-try:
-    import gwcs
-    if Version(gwcs.__version__) > Version('0.12.0'):
-        from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
-        _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
-        _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
-        _NO_JWST_SUPPORT = False
-    else:
-        _NO_JWST_SUPPORT = True
-except ImportError:
-    _NO_JWST_SUPPORT = True
+_S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+_C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
 
-@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 @pytest.mark.parametrize('x,y,z', [
     (1, 0, 0),
     (0, 1, 0),
@@ -39,7 +28,6 @@ def test_cartesian_spherical_cartesian_roundtrip_special(x, y, z):
     assert np.allclose((x, y, z), xyz, rtol=0, atol=feps)
 
 
-@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_cartesian_spherical_cartesian_roundtrip_rand():
     feps = 100 * np.finfo(np.double).eps
     xyz = np.random.random((100, 3))
@@ -51,7 +39,6 @@ def test_cartesian_spherical_cartesian_roundtrip_rand():
     assert np.allclose(rz, z, rtol=0, atol=feps)
 
 
-@pytest.mark.skipif(_NO_JWST_SUPPORT, reason="requires gwcs>=0.12.1")
 def test_spherical_cartesian_spherical_roundtrip_ugrid():
     feps = 1000 * np.finfo(np.double).eps
     angles = np.linspace(-180, 180, 13)

--- a/tweakwcs/tpwcs.py
+++ b/tweakwcs/tpwcs.py
@@ -11,20 +11,10 @@ of ``WCS``.
 import logging
 from copy import deepcopy
 from abc import ABC, abstractmethod
-from packaging.version import Version
 
 import numpy as np
-
-try:
-    import gwcs
-    if Version(gwcs.__version__) > Version('0.12.0'):
-        from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
-        _GWCS_VER_GT_0P12 = True
-    else:
-        _GWCS_VER_GT_0P12 = False
-except ImportError:
-    _GWCS_VER_GT_0P12 = False
-
+import gwcs
+from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
 from astropy.modeling import CompoundModel
 from astropy.modeling.models import (
     AffineTransformation2D, Scale, Identity, Mapping, Const1D,
@@ -589,14 +579,6 @@ class JWSTgWCS(TPWCS):
             Dictionary that will be merged to the object's ``meta`` fields.
 
         """
-        if not _GWCS_VER_GT_0P12:
-            raise NotImplementedError(
-                "JWST support requires gwcs version > 0.12.0 "
-                "To pip install minimal required version, do the following:\n"
-                "pip install git+https://github.com/spacetelescope/gwcs@"
-                "1c1cb3bb35caddef80fb760ea68bc71e189d32de"
-            )
-
         valid, message = self._check_wcs_structure(wcs)
         if not valid:
             raise ValueError("Unsupported WCS structure: {}".format(message))

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -12,46 +12,19 @@ import os
 import logging
 import numbers
 from copy import deepcopy
-from packaging.version import Version
 
 import numpy as np
 from astropy import table
 from astropy.utils.decorators import deprecated_renamed_argument
 from spherical_geometry.polygon import SphericalPolygon, MalformedPolygonError
+from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
 
 from . linearfit import SUPPORTED_FITGEOM_MODES
 
-try:
-    import gwcs
-    if Version(gwcs.__version__) > Version('0.12.0'):
-        from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
-        _GWCS_VER_GT_0P12 = True
-    else:
-        _GWCS_VER_GT_0P12 = False
 
-except ImportError:
-    _GWCS_VER_GT_0P12 = False
+_S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+_C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
 
-
-if _GWCS_VER_GT_0P12:
-    _S2C = SphericalToCartesian(name='s2c', wrap_lon_at=180)
-    _C2S = CartesianToSpherical(name='c2s', wrap_lon_at=180)
-
-else:
-    def _S2C(phi, theta):
-        phi = np.deg2rad(phi)
-        theta = np.deg2rad(theta)
-        cs = np.cos(theta)
-        x = cs * np.cos(phi)
-        y = cs * np.sin(phi)
-        z = np.sin(theta)
-        return x, y, z
-
-    def _C2S(x, y, z):
-        h = np.hypot(x, y)
-        phi = np.rad2deg(np.arctan2(y, x))
-        theta = np.rad2deg(np.arctan2(z, h))
-        return phi, theta
 
 from .wcsutils import planar_rot_3d
 from .tpwcs import TPWCS


### PR DESCRIPTION
In https://github.com/spacetelescope/tweakwcs/pull/155 switched to accessing `gwcs` pipeline via `Step` properties instead of pipeline indexing. This requires `gwcs>=0.14`. Requiring this in `setup.py` essentially makes unnecessary all the version checks for the `gwcs` package that are in the current code.
This PR increases `gwcs` version requirement and removes version checks.