### PR TITLE
Expose clip_accum parameter in top-level functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@
 Release Notes
 =============
 
-.. 0.7.5 (unreleased)
+.. 0.7.6 (unreleased)
    ==================
+
+0.7.5 (unreleased)
+==================
+
+- Exposed in top-level functions parameter ``clip_accum`` that controls
+  whether or not to reset the list of "bad" (clipped out) sources after each
+  clipping iteration during model fitting. [#169]
 
 0.7.4 (13-April-2022)
 =====================

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -36,7 +36,7 @@ log.setLevel(logging.DEBUG)
 
 
 def fit_wcs(refcat, imcat, tpwcs, ref_tpwcs=None, fitgeom='general', nclip=3,
-            sigma=(3.0, 'rmse')):
+            sigma=(3.0, 'rmse'), clip_accum=False):
     """ "Tweak" **a single** image's ``WCS`` by fitting image catalog to a
     reference catalog. This is a simplified version of `align_wcs` that does
     not perform matching and is limited to the fitting part.
@@ -103,6 +103,14 @@ def fit_wcs(refcat, imcat, tpwcs, ref_tpwcs=None, fitgeom='general', nclip=3,
         the default error estimate ``'rmse'`` is assumed.
 
         This parameter is ignored when ``nclip`` is either `None` or 0.
+
+    clip_accum: bool, optional
+        Indicates whether or not to reset the list of "bad" (clipped out)
+        sources after each clipping iteration. When set to `True` the list
+        only grows with each iteration as "bad" positions never re-enter
+        the pool of available position for the fit. By default the list of
+        "bad" source positions is purged at each iteration. This parameter
+        is ignored when ``nclip`` is either `None` or 0.
 
     Returns
     -------
@@ -253,7 +261,8 @@ def fit_wcs(refcat, imcat, tpwcs, ref_tpwcs=None, fitgeom='general', nclip=3,
         minobj=None,
         fitgeom=fitgeom,
         nclip=nclip,
-        sigma=sigma
+        sigma=sigma,
+        clip_accum=clip_accum
     )
 
     tpwcs.meta['fit_info'] = wimcat.fit_info
@@ -274,7 +283,8 @@ def fit_wcs(refcat, imcat, tpwcs, ref_tpwcs=None, fitgeom='general', nclip=3,
 
 def align_wcs(wcscat, refcat=None, ref_tpwcs=None, enforce_user_order=True,
               expand_refcat=False, minobj=None, match=TPMatch(),
-              fitgeom='general', nclip=3, sigma=(3.0, 'rmse')):
+              fitgeom='general', nclip=3, sigma=(3.0, 'rmse'),
+              clip_accum=False):
     r"""
     Align (groups of) image catalogs by adjusting the parameters of their
     WCS based on fits between matched sources in these catalogs and a reference
@@ -413,6 +423,14 @@ def align_wcs(wcscat, refcat=None, ref_tpwcs=None, enforce_user_order=True,
         the default error estimate ``'rmse'`` is assumed.
 
         This parameter is ignored when ``nclip`` is either `None` or 0.
+
+    clip_accum: bool, optional
+        Indicates whether or not to reset the list of "bad" (clipped out)
+        sources after each clipping iteration. When set to `True` the list
+        only grows with each iteration as "bad" positions never re-enter
+        the pool of available position for the fit. By default the list of
+        "bad" source positions is purged at each iteration. This parameter
+        is ignored when ``nclip`` is either `None` or 0.
 
     Returns
     -------
@@ -638,7 +656,8 @@ def align_wcs(wcscat, refcat=None, ref_tpwcs=None, enforce_user_order=True,
             minobj=minobj,
             fitgeom=fitgeom,
             nclip=nclip,
-            sigma=sigma
+            sigma=sigma,
+            clip_accum=clip_accum
         )
 
         for wcat in current_wcat:

--- a/tweakwcs/linearfit.py
+++ b/tweakwcs/linearfit.py
@@ -149,9 +149,10 @@ def iter_linear_fit(xy, uv, wxy=None, wuv=None,
     clip_accum: bool, optional
         Indicates whether or not to reset the list of "bad" (clipped out)
         sources after each clipping iteration. When set to `True` the list
-        only grows with each iteration as "bad" positions never re-enter the
-        pool of available position for the fit. By default the list of
-        "bad" source positions is purged at each iteration.
+        only grows with each iteration as "bad" positions never re-enter
+        the pool of available position for the fit. By default the list of
+        "bad" source positions is purged at each iteration. This parameter
+        is ignored when ``nclip`` is either `None` or 0.
 
     Returns
     -------

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -865,7 +865,7 @@ class WCSGroupCatalog(object):
         return nmatches, mref_idx, minput_idx
 
     def fit2ref(self, refcat, tanplane_wcs, fitgeom='general', nclip=3,
-                sigma=(3.0, 'rmse')):
+                sigma=(3.0, 'rmse'), clip_accum=False):
         """
         Perform linear fit of this group's combined catalog to the reference
         catalog. When either/both group's catalog or/and the reference catalog
@@ -905,6 +905,14 @@ class WCSGroupCatalog(object):
             the default error estimate ``'rmse'`` is assumed.
 
             This parameter is ignored when ``nclip`` is either `None` or 0.
+
+        clip_accum: bool, optional
+            Indicates whether or not to reset the list of "bad" (clipped out)
+            sources after each clipping iteration. When set to `True` the list
+            only grows with each iteration as "bad" positions never re-enter
+            the pool of available position for the fit. By default the list of
+            "bad" source positions is purged at each iteration. This parameter
+            is ignored when ``nclip`` is either `None` or 0.
 
         Notes
         -----
@@ -978,7 +986,8 @@ class WCSGroupCatalog(object):
 
         fit = iter_linear_fit(
             refxy, im_xyref, ref_weight, im_weight,
-            fitgeom=fitgeom, nclip=nclip, sigma=sigma, center=None
+            fitgeom=fitgeom, nclip=nclip, sigma=sigma, center=None,
+            clip_accum=clip_accum
         )
 
         # re-compute shifts for the center at (0, 0):
@@ -1025,7 +1034,8 @@ class WCSGroupCatalog(object):
             imcat.tpwcs.set_correction(matrix, shift, ref_tpwcs=ref_tpwcs, meta=meta)
 
     def align_to_ref(self, refcat, ref_tpwcs=None, match=None, minobj=None,
-                     fitgeom='rscale', nclip=3, sigma=(3.0, 'rmse')):
+                     fitgeom='rscale', nclip=3, sigma=(3.0, 'rmse'),
+                     clip_accum=False):
         """
         Matches sources from the image catalog to the sources in the
         reference catalog, finds the affine transformation between matched
@@ -1143,6 +1153,14 @@ class WCSGroupCatalog(object):
             This parameter is ignored when ``nclip`` is either `None` or 0
             or when ``match`` is `False`.
 
+        clip_accum: bool, optional
+            Indicates whether or not to reset the list of "bad" (clipped out)
+            sources after each clipping iteration. When set to `True` the list
+            only grows with each iteration as "bad" positions never re-enter
+            the pool of available position for the fit. By default the list of
+            "bad" source positions is purged at each iteration. This parameter
+            is ignored when ``nclip`` is either `None` or 0.
+
         Returns
         -------
         bool
@@ -1186,7 +1204,8 @@ class WCSGroupCatalog(object):
             return False
 
         fit = self.fit2ref(refcat=refcat, tanplane_wcs=ref_tpwcs,
-                           fitgeom=fitgeom, nclip=nclip, sigma=sigma)
+                           fitgeom=fitgeom, nclip=nclip, sigma=sigma,
+                           clip_accum=clip_accum)
 
         fit_info = {
             'fitgeom': fitgeom,


### PR DESCRIPTION
Closes #168 

This PR exposes ``clip_accum`` parameter that fine-tunes model fitting process to higher-level functions.