### PR TITLE
Fix bin size in 2D histogram used in matching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,18 @@
 Release Notes
 =============
 
-.. 0.8.1 (unreleased)
+.. 0.8.2 (unreleased)
    ==================
+
+0.8.1 (unreleased)
+==================
+
+- Fixed a bug in the ``XYXYMatch`` due to which bin size for the 2D histogram
+  pre-match alignment did not account for the pixel scale in the tangent plane.
+  This required a change in the API of ``XYXYMatch.__call__`` which now
+  _must_ have ``tp_pscale`` as input and also inputs catalogs now _must_
+  contain ``'TPx'`` and ``'TPy'`` columns. [#173]
+
 
 0.8.0 (25-August-2022)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Release Notes
   _must_ have ``tp_pscale`` as input and also inputs catalogs now _must_
   contain ``'TPx'`` and ``'TPy'`` columns. [#173]
 
+- Deprecated ``'tp_wcs'`` argument of the ``XYXYMatch.__call__()`` method.
+  Use ``'tp_pscale'`` instead. [#173]
+
 
 0.8.0 (25-August-2022)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,8 @@ Release Notes
 .. 0.8.2 (unreleased)
    ==================
 
-0.8.1 (unreleased)
-==================
+0.8.1 (23-December-2022)
+========================
 
 - Fixed a bug in the ``XYXYMatch`` due to which bin size for the 2D histogram
   pre-match alignment did not account for the pixel scale in the tangent plane.

--- a/tweakwcs/correctors.py
+++ b/tweakwcs/correctors.py
@@ -74,6 +74,7 @@ class WCSCorrector(ABC):
     and for managing tangent-plane corrections.
 
     """
+    units = None
 
     def __init__(self, wcs, meta=None):
         """
@@ -278,6 +279,8 @@ class FITSWCSCorrector(WCSCorrector):
         supported.
 
     """
+    units = 'pixel'
+
     def __init__(self, wcs, meta=None):
         """
         Parameters
@@ -557,6 +560,8 @@ class JWSTWCSCorrector(WCSCorrector):
     tangent-plane corrections.
 
     """
+    units = 'arcsec'
+
     def __init__(self, wcs, wcsinfo, meta=None):
         """
         Parameters

--- a/tweakwcs/tests/test_multichip_fitswcs.py
+++ b/tweakwcs/tests/test_multichip_fitswcs.py
@@ -10,7 +10,7 @@ import pytest
 import tweakwcs
 
 
-def _match(x, y, tp_pscale, tp_units):
+def _match(x, y, tp_pscale, tp_units, **kwargs):
     lenx = len(x)
     leny = len(y)
     if lenx == leny:

--- a/tweakwcs/tests/test_multichip_fitswcs.py
+++ b/tweakwcs/tests/test_multichip_fitswcs.py
@@ -10,7 +10,7 @@ import pytest
 import tweakwcs
 
 
-def _match(x, y):
+def _match(x, y, tp_pscale, tp_units):
     lenx = len(x)
     leny = len(y)
     if lenx == leny:

--- a/tweakwcs/tests/test_multichip_jwst.py
+++ b/tweakwcs/tests/test_multichip_jwst.py
@@ -112,7 +112,7 @@ def _make_gwcs_wcs(fits_hdr):
     return gw
 
 
-def _match(x, y, tp_pscale, tp_units):
+def _match(x, y, tp_pscale, tp_units, **kwargs):
     lenx = len(x)
     leny = len(y)
     if lenx == leny:

--- a/tweakwcs/tests/test_multichip_jwst.py
+++ b/tweakwcs/tests/test_multichip_jwst.py
@@ -112,7 +112,7 @@ def _make_gwcs_wcs(fits_hdr):
     return gw
 
 
-def _match(x, y):
+def _match(x, y, tp_pscale, tp_units):
     lenx = len(x)
     leny = len(y)
     if lenx == leny:

--- a/tweakwcs/tests/test_wcsimage.py
+++ b/tweakwcs/tests/test_wcsimage.py
@@ -236,6 +236,24 @@ def test_wcsgroupcat_update_bb_no_images(mock_fits_wcs, rect_imcat):
     assert len(g.polygon) == 0
 
 
+def test_wcsgroupcat_empty_cat(mock_fits_wcs, rect_imcat):
+    imcat = Table([[], [], [], []], names=('x', 'y', 'TPx', 'TPy'))
+    corr = FITSWCSCorrector(mock_fits_wcs)
+
+    ra, dec = mock_fits_wcs.all_pix2world(rect_imcat.catalog['x'],
+                                          rect_imcat.catalog['y'], 0)
+    refcat = Table([ra, dec], names=('RA', 'DEC'))
+    ref = RefCatalog(refcat)
+
+    w = WCSImageCatalog(imcat, corr)
+    ref.calc_tanp_xy(tanplane_wcs=rect_imcat.corrector)
+    g = WCSGroupCatalog([w])
+    g.calc_tanp_xy(tanplane_wcs=rect_imcat.corrector)
+
+    nmatches, *_ = g.match2ref(ref, match=XYXYMatch())
+    assert nmatches == 0
+
+
 def test_wcsgroupcat_create_group_catalog(mock_fits_wcs, rect_imcat):
     w1 = copy.deepcopy(rect_imcat)
     w2 = copy.deepcopy(rect_imcat)

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -867,7 +867,8 @@ class WCSGroupCatalog(object):
                 refcat.catalog,
                 self._catalog,
                 tp_pscale=tp_pscale,
-                tp_units=tp_units
+                tp_units=tp_units,
+                tp_wcs=self._images[0].corrector
             )
             nmatches = len(mref_idx)
 

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -825,6 +825,20 @@ class WCSGroupCatalog(object):
             ``'TPy'`` that represent the source coordinates in some common
             (to both catalogs) coordinate system.
 
+        Returns
+        -------
+
+        nmatches: int
+            Number of found matches.
+
+        mref_idx: numpy.ndarray
+            Integer array indicating indices of sources in the reference
+            catalog that were matched to sources in group's ``catalog``.
+
+        minput_idx: numpy.ndarray
+            Integer array indicating indices of sources in group's ``catalog``
+            that were matched to sources in the reference catalog.
+
         """
         colnames = self._catalog.colnames
         catlen = len(self._catalog)
@@ -848,20 +862,15 @@ class WCSGroupCatalog(object):
                 raise RuntimeError("'calc_tanp_xy()' should have been run "
                                    "prior to match2ref()")
 
-            try:
-                if self._images:
-                    tp_pscale = self._images[0].corrector.tanp_center_pixel_scale
-                else:
-                    tp_pscale = 1.0
+            if catlen == 0:
+                return 0, np.array([], dtype=int), np.array([], dtype=int)
 
+            try:
+                tp_pscale = self._images[0].corrector.tanp_center_pixel_scale
             except NotImplementedError:
                 tp_pscale = 1.0
-
             finally:
-                if self._images:
-                    tp_units = self._images[0].corrector.units
-                else:
-                    tp_units = 'tangent plane units'
+                tp_units = self._images[0].corrector.units
 
             mref_idx, minput_idx = match(
                 refcat.catalog,

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -876,8 +876,7 @@ class WCSGroupCatalog(object):
                 refcat.catalog,
                 self._catalog,
                 tp_pscale=tp_pscale,
-                tp_units=tp_units,
-                tp_wcs=self._images[0].corrector
+                tp_units=tp_units
             )
             nmatches = len(mref_idx)
 

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -848,7 +848,27 @@ class WCSGroupCatalog(object):
                 raise RuntimeError("'calc_tanp_xy()' should have been run "
                                    "prior to match2ref()")
 
-            mref_idx, minput_idx = match(refcat.catalog, self._catalog)
+            try:
+                if self._images:
+                    tp_pscale = self._images[0].corrector.tanp_center_pixel_scale
+                else:
+                    tp_pscale = 1.0
+
+            except NotImplementedError:
+                tp_pscale = 1.0
+
+            finally:
+                if self._images:
+                    tp_units = self._images[0].corrector.units
+                else:
+                    tp_units = 'tangent plane units'
+
+            mref_idx, minput_idx = match(
+                refcat.catalog,
+                self._catalog,
+                tp_pscale=tp_pscale,
+                tp_units=tp_units
+            )
             nmatches = len(mref_idx)
 
         # matched_ref_id:


### PR DESCRIPTION
The bins of the 2D histogram used to find initial shifts for matching of JWST catalogs are too large compared to pixel size due to the fact that bins were in the tangent plane units and did not take into account pixel scale.