### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -49,7 +49,9 @@ jobs:
       displayName: run test
 
     - bash: |
-        codecov -t $codecov_token
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov -t $codecov_token
       env:
         codecov_token: $(CODECOV_TOKEN)
       condition: ne( variables['Agent.OS'], 'Windows_NT' )

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ INSTALL_REQUIRES = [
 TESTS_REQUIRE = [
     'pytest',
     'pytest-cov',
-    'codecov',
     'scipy'
 ]
 


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI