### PR TITLE
Allow approximate computation of bounding polygons for large groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,18 @@
 Release Notes
 =============
 
-.. 0.8.2 (unreleased)
+.. 0.8.3 (unreleased)
    ==================
+
+0.8.2 (13-April-2023)
+=====================
+
+- Added ``bb_policy`` argument to the ``WCSGroupCatalog`` to control when
+  to switch to an aproximate method of computing of the bounding polygon of
+  a group of images. The default value is set to 50. Also added equivalent
+  ``group_bb_policy`` argument to both ``fit_wcs`` and ``align_wcs``
+  functions. [#176]
+
 
 0.8.1 (23-December-2022)
 ========================


### PR DESCRIPTION
This PR adds an argument (`group_bb_policy` and `bb_policy`) that controls how the bounding box is computed for groups of images. It introduces a new algorithm that approximates the bounding box using convex hull of individual images' bounding polygons instead of computing the exact union of individual polygons. The exact algorithm becomes extremely slow for large groups of images (>50).