### PR TITLE
Bugfix for numpy 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ PACKAGE_DATA = {
 }
 
 INSTALL_REQUIRES = [
-    'numpy',
+    'numpy>=1.21',
     'astropy>=5.0.4',
     'gwcs>=0.14.0',
     'stsci.stimage',

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -56,7 +56,7 @@ def _is_longdouble_lte_flt_type(flt_type=np.double):
 
 def _find_max_linalg_type():
     max_type = None
-    for np_type in np.sctypes['float'][::-1]:  # pragma: no branch
+    for np_type in np.core.sctypes['float'][::-1]:  # pragma: no branch
         try:
             r = np.linalg.inv(np.identity(2, dtype=np_type))
             max_type = np_type


### PR DESCRIPTION
Numpy 2.0 jobs are failing when running with tweakwcs because `np.sctypes` has been removed, but is still accessible via `np.core.sctypes`. This PR makes that change.