### PR TITLE
Compatability with numpy 2.0

### DIFF
--- a/tweakwcs/correctors.py
+++ b/tweakwcs/correctors.py
@@ -474,9 +474,9 @@ class FITSWCSCorrector(WCSCorrector):
             ra = np.atleast_1d(ra)
             dec = np.atleast_1d(dec)
         x, y = self._wcs.all_world2pix(ra, dec, 0, tolerance=1e-6, maxiter=50)
-        if not ndim:
-            x = float(x)
-            y = float(y)
+        if not ndim and x.size == 1:
+            x = float(x[0])
+            y = float(y[0])
         return x, y
 
     def world_to_tanp(self, ra, dec):

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -54,26 +54,6 @@ def _is_longdouble_lte_flt_type(flt_type=np.double):
     return lte_flt
 
 
-def _find_max_linalg_type():
-    max_type = None
-    for np_type in np.sctypes['float'][::-1]:  # pragma: no branch
-        try:
-            r = np.linalg.inv(np.identity(2, dtype=np_type))
-            max_type = np_type
-            eps = 100 * np.finfo(max_type).eps
-            if np.max(np.abs(r - np.identity(2, dtype=np_type))) > eps:  # pragma: no branch
-                log.warning('Loss of accuracy during matrix inversion.')
-            break
-        except TypeError:
-            continue
-
-
-_USE_NUMPY_LINALG_INV = _is_longdouble_lte_flt_type(flt_type=np.double)
-_MAX_LINALG_TYPE = _find_max_linalg_type()
-if _MAX_LINALG_TYPE is None:
-    _USE_NUMPY_LINALG_INV = False  # pragma: no cover
-
-
 def inv(m):
     """ This function computes inverse matrix using Gauss-Jordan elimination
     with full pivoting. Computations are performed using ``numpy.longdouble``
@@ -95,13 +75,6 @@ def inv(m):
 
     """
     # check that matrix is square:
-    if _USE_NUMPY_LINALG_INV:
-        invm = np.linalg.inv(np.array(m, dtype=_MAX_LINALG_TYPE))
-        # detect singularity:
-        if not np.all(np.isfinite(invm)):
-            raise np.linalg.LinAlgError('Singular matrix.')
-        return invm
-
     m = np.array(m, dtype=np.longdouble)
     if len(m.shape) != 2 or m.shape[0] != m.shape[1]:
         raise np.linalg.LinAlgError("Input matrix must be a square matrix.")

--- a/tweakwcs/tests/test_linalg.py
+++ b/tweakwcs/tests/test_linalg.py
@@ -30,81 +30,34 @@ def test_inv_order2():
     scale2 = 0.7 + 0.6 * np.random.random()
     a = linearfit.build_fit_matrix((angle1, angle2), (scale1, scale2))
 
-    # invert using numpy.linalg:
-    use_numpy = linalg._USE_NUMPY_LINALG_INV
-    linalg._USE_NUMPY_LINALG_INV = True
+    x = linalg.inv(a)
+    r = np.identity(2) - np.dot(a, x)
 
-    try:
-        x = linalg.inv(a)
-        r = np.identity(2) - np.dot(a, x)
-
-        # Use Morris Newman's formula to asses the quality of the inversion
-        # (see https://nvlpubs.nist.gov/nistpubs/jres/78B/jresv78Bn2p65_A1b.pdf
-        #  January 3, 1974).
-        err = 2.0 * np.abs(np.dot(x, r)).max() / (1.0 - np.abs(r).max())
-        assert err < feps
-
-    finally:
-        linalg._USE_NUMPY_LINALG_INV = use_numpy
-
-    # invert using tweakwcs.linalg:
-    linalg._USE_NUMPY_LINALG_INV = False
-
-    try:
-        x = linalg.inv(a)
-        r = np.identity(2) - np.dot(a, x)
-
-        # Use Morris Newman's formula to asses the quality of the inversion
-        # (see https://nvlpubs.nist.gov/nistpubs/jres/78B/jresv78Bn2p65_A1b.pdf
-        #  January 3, 1974).
-        err = 2.0 * np.abs(np.dot(x, r)).max() / (1.0 - np.abs(r).max())
-        assert err < feps
-
-    finally:
-        linalg._USE_NUMPY_LINALG_INV = use_numpy
+    # Use Morris Newman's formula to asses the quality of the inversion
+    # (see https://nvlpubs.nist.gov/nistpubs/jres/78B/jresv78Bn2p65_A1b.pdf
+    #  January 3, 1974).
+    err = 2.0 * np.abs(np.dot(x, r)).max() / (1.0 - np.abs(r).max())
+    assert err < feps
 
 
-@pytest.mark.parametrize('use_numpy_inv', [True, False])
-def test_inv_nonsquare(use_numpy_inv):
-    use_numpy = linalg._USE_NUMPY_LINALG_INV
-    linalg._USE_NUMPY_LINALG_INV = use_numpy_inv
+def test_inv_nonsquare():
     with pytest.raises(np.linalg.LinAlgError):
-        try:
-            linalg.inv(np.empty((1, 2)))
-        finally:
-            linalg._USE_NUMPY_LINALG_INV = use_numpy
+        linalg.inv(np.empty((1, 2)))
 
 
-@pytest.mark.parametrize('use_numpy_inv', [True, False])
-def test_inv_singular(use_numpy_inv):
-    use_numpy = linalg._USE_NUMPY_LINALG_INV
-    linalg._USE_NUMPY_LINALG_INV = use_numpy_inv
+def test_inv_singular():
     arr = np.array([[1.0, 1.0], [2.0, 2.0]])
     with pytest.raises(np.linalg.LinAlgError):
-        try:
-            linalg.inv(arr)
-        finally:
-            linalg._USE_NUMPY_LINALG_INV = use_numpy
+        linalg.inv(arr)
 
 
-@pytest.mark.parametrize('use_numpy_inv', [True, False])
-def test_inv_nan(use_numpy_inv):
-    use_numpy = linalg._USE_NUMPY_LINALG_INV
-    linalg._USE_NUMPY_LINALG_INV = use_numpy_inv
+def test_inv_nan():
     arr = np.array([[1.0, 1.0, -1.], [2.0, -2.1, 4.0], [-1.0, np.nan, 1.0]])
     with pytest.raises(np.linalg.LinAlgError):
-        try:
-            linalg.inv(arr)
-        finally:
-            linalg._USE_NUMPY_LINALG_INV = use_numpy
+        linalg.inv(arr)
 
 
 def test_inv_high_dim():
-    use_numpy = linalg._USE_NUMPY_LINALG_INV
-    linalg._USE_NUMPY_LINALG_INV = False
     arr = np.random.random((4, 4, 4))
     with pytest.raises(np.linalg.LinAlgError):
-        try:
-            linalg.inv(arr)
-        finally:
-            linalg._USE_NUMPY_LINALG_INV = use_numpy
+        linalg.inv(arr)

--- a/tweakwcs/tests/test_linearfit.py
+++ b/tweakwcs/tests/test_linearfit.py
@@ -9,7 +9,7 @@ import math
 import pytest
 import numpy as np
 from astropy.modeling.models import Shift, Rotation2D
-from tweakwcs import linearfit, linalg
+from tweakwcs import linearfit
 
 
 _LARGE_SAMPLE_SIZE = 1000

--- a/tweakwcs/tests/test_linearfit.py
+++ b/tweakwcs/tests/test_linearfit.py
@@ -26,7 +26,7 @@ _TRANSFORM_SELECTOR = {
 }
 
 _ATOL = 10 * _LARGE_SAMPLE_SIZE * np.sqrt(
-    np.finfo(linalg._MAX_LINALG_TYPE).eps
+    np.finfo(None).eps
 )
 
 

--- a/tweakwcs/tests/test_linearfit.py
+++ b/tweakwcs/tests/test_linearfit.py
@@ -26,7 +26,7 @@ _TRANSFORM_SELECTOR = {
 }
 
 _ATOL = 10 * _LARGE_SAMPLE_SIZE * np.sqrt(
-    np.finfo(None).eps
+    np.finfo(np.float64).eps
 )
 
 


### PR DESCRIPTION
Numpy 2.0 removes `np.sctypes` which is used in `linalg.py`:
https://github.com/spacetelescope/tweakwcs/blob/a9bf1b1758024980cfc5a2a2af2369e8c52b0562/tweakwcs/linalg.py#L59

While looking to the use in `_find_max_linalg_type` I realized this function does not return a value.
https://github.com/spacetelescope/tweakwcs/blob/a9bf1b1758024980cfc5a2a2af2369e8c52b0562/tweakwcs/linalg.py#L57-L68

It is only used in the same file (`linalg.py`):
https://github.com/spacetelescope/tweakwcs/blob/a9bf1b1758024980cfc5a2a2af2369e8c52b0562/tweakwcs/linalg.py#L71-L74
and the lack of a return value makes `_MAX_LINALG_TYPE` always `None` and `_USE_NUMPY_LINALG_INV` always `False`.

I am not sure if this is the right approach, but given the findings above I removed the otherwise unused `_find_max_linalg_type` `_MAX_LINALG_TYPE` and `_USE_NUMPY_LINALG_INV` and updated the tests to not test for `_USE_NUMPY_LINALG_INV` (which appears to never be used outside of tests because of the above issue).

Testing locally with numpy 2.0 I saw a few other warnings which were addressed by:
- using `float64` instead of `None` for computing the `_ATOL` in the tests
- selecting the single element from an array before converting to a float in `correctors.py`

This PR does not update the CI to test against numpy 2.0 because I'm not sure how the CI is set up. Perhaps @zacharyburnett knows the right magic incantations?