### PR TITLE
Fix a bug preventing usage of numpy.linalg.inv and fix numpy 2.0 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,18 @@
 Release Notes
 =============
 
-.. 0.8.3 (unreleased)
+.. 0.8.4 (unreleased)
    ==================
+
+0.8.3 (12-September-2023)
+=========================
+
+- Fixed a bug in the ``linalg`` module due to which computation of the inverse
+  matrix would fallback to custom implementation instead of using ``numpy``
+  implementation. [#185]
+
+- Fixed incompatibilities with the future (version 2.0) release of
+  ``numpy``. [#185]
 
 0.8.2 (13-April-2023)
 =====================

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2018, Association of Universities for Research in Astronomy
+Copyright (C) 2023, Association of Universities for Research in Astronomy
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docs/rtd-pip-requirements.txt
+++ b/docs/rtd-pip-requirements.txt
@@ -4,7 +4,7 @@ astropy
 numpydoc
 sphinx
 sphinx-automodapi
-sphinx-rtd-theme
+sphinx_rtd_theme>1.2.0
 stsci-rtd-theme
 sphinx-astropy
 graphviz

--- a/tweakwcs/correctors.py
+++ b/tweakwcs/correctors.py
@@ -474,9 +474,10 @@ class FITSWCSCorrector(WCSCorrector):
             ra = np.atleast_1d(ra)
             dec = np.atleast_1d(dec)
         x, y = self._wcs.all_world2pix(ra, dec, 0, tolerance=1e-6, maxiter=50)
-        if not ndim:
-            x = float(x)
-            y = float(y)
+        if not ndim and np.size(x) == 1:
+            # convert to scalars:
+            x = float(x[0])
+            y = float(y[0])
         return x, y
 
     def world_to_tanp(self, ra, dec):

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -56,7 +56,7 @@ def _is_longdouble_lte_flt_type(flt_type=np.double):
 
 def _find_max_linalg_type():
     max_type = None
-    for np_type in np.core.sctypes['float'][::-1]:  # pragma: no branch
+    for np_type in [np.longdouble, np.float64, np.float32]:  # pragma: no branch
         try:
             r = np.linalg.inv(np.identity(2, dtype=np_type))
             max_type = np_type

--- a/tweakwcs/linalg.py
+++ b/tweakwcs/linalg.py
@@ -56,7 +56,7 @@ def _is_longdouble_lte_flt_type(flt_type=np.double):
 
 def _find_max_linalg_type():
     max_type = None
-    for np_type in np.sctypes['float'][::-1]:  # pragma: no branch
+    for np_type in np.core.sctypes['float'][::-1]:  # pragma: no branch
         try:
             r = np.linalg.inv(np.identity(2, dtype=np_type))
             max_type = np_type
@@ -66,6 +66,7 @@ def _find_max_linalg_type():
             break
         except TypeError:
             continue
+    return max_type
 
 
 _USE_NUMPY_LINALG_INV = _is_longdouble_lte_flt_type(flt_type=np.double)
@@ -96,7 +97,7 @@ def inv(m):
     """
     # check that matrix is square:
     if _USE_NUMPY_LINALG_INV:
-        invm = np.linalg.inv(np.array(m, dtype=_MAX_LINALG_TYPE))
+        invm = np.linalg.inv(np.array(m).astype(_MAX_LINALG_TYPE))
         # detect singularity:
         if not np.all(np.isfinite(invm)):
             raise np.linalg.LinAlgError('Singular matrix.')

--- a/tweakwcs/tests/test_linearfit.py
+++ b/tweakwcs/tests/test_linearfit.py
@@ -6,6 +6,7 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 from itertools import product
 import math
+import sys
 import pytest
 import numpy as np
 from astropy.modeling.models import Shift, Rotation2D
@@ -25,9 +26,12 @@ _TRANSFORM_SELECTOR = {
     'general': linearfit.fit_general,
 }
 
-_ATOL = 10 * _LARGE_SAMPLE_SIZE * np.sqrt(
-    np.finfo(linalg._MAX_LINALG_TYPE).eps
-)
+if linalg._MAX_LINALG_TYPE is not None:
+    _ATOL = 10 * _LARGE_SAMPLE_SIZE * np.sqrt(
+        np.finfo(linalg._MAX_LINALG_TYPE).eps
+    )
+else:
+    _ATOL = 10 * _LARGE_SAMPLE_SIZE * np.sqrt(sys.float_info.epsilon)
 
 
 def test_test_transform_selector():


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/spacetelescope/tweakwcs/pull/184 and also fixes incompatibility with future numpy 2.0 (this is the fix as proposed in #182).

Also fixed RTD build as in https://github.com/spacetelescope/jwst/pull/7787

Closes #184 