### PR TITLE
Improve how reference catalog is expanded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,16 @@
 Release Notes
 =============
 
-.. 0.8.5 (unreleased)
+.. 0.8.7 (unreleased)
    ==================
+
+0.8.6 (unreleased)
+==================
+
+- Improved the quality of the *expanded* reference catalog when
+  ``expand_refcat`` is set to `True` in the ``align_wcs`` function by not
+  using input catalogs that failed to align in the expanded reference
+  catalog. [#195]
 
 
 0.8.5 (30-November-2023)

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -765,6 +765,7 @@ def overlap_matrix(images):
             m[i, j] = area
     return m
 
+
 @deprecated("0.8.6")
 def max_overlap_pair(images, enforce_user_order):
     """
@@ -906,7 +907,7 @@ def _max_overlap_pair(images, enforce_user_order):
     -------
     (im1, im2, overlap_area)
         Returns a tuple of two images - elements of input ``images`` list and
-        the area of the overlap of the two images in steradians. 
+        the area of the overlap of the two images in steradians.
         When ``enforce_user_order`` is `True`, images are returned in the
         order in which they appear in the input ``images`` list. When the
         number of input images is smaller than two, ``im1`` and ``im2`` may
@@ -920,7 +921,7 @@ def _max_overlap_pair(images, enforce_user_order):
 
     elif nimg == 1:
         return images[0], None, None
-        
+
     elif nimg == 2 or enforce_user_order:
         # for the special case when only two images are provided
         # return (refimage, image) in the same order as provided in 'images'.


### PR DESCRIPTION
This PR addresses the issue `JP-3468` (excerpt):

> When running the TweakRegStep with expand_refcat=True, if aligning an image fails, its sources are still added to the reference catalog.  This breaks the astrometric consistency of the reference catalog, and the next image(s) can lock onto these unaligned sources (or just not match and add even more unaligned sources).  This can cause a cascade of misaligned images that can report the alignment as successful. 

Reported by @Vb2341 