### PR TITLE
[SCSB-145] require Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,42 +27,20 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-xdist
-          python-version: 3.8
-        - macos: test-xdist
-          python-version: 3.8
-        - windows: test-xdist
-          python-version: 3.8
-        - linux: test-numpy121-xdist
-          python-version: 3.9
-        - linux: test-numpy123-xdist
-          python-version: 3.9
-        - linux: test-numpy125-xdist
-          python-version: 3.9
-        - macos: test-numpy121-xdist
-          python-version: 3.10
-        - linux: test-numpy125-xdist
-          python-version: 3.10
-        - linux: test-xdist
-          python-version: 3.11
+        - macos: py310-numpy121-xdist
+        - linux: py310-numpy125-xdist
+        - linux: py311-xdist
           pytest-results-summary: true
-        - macos: test-xdist
-          python-version: 3.11
+        - macos: py311-xdist
           pytest-results-summary: true
-        - windows: test-xdist
-          python-version: 3.11
+        - windows: py311-xdist
           pytest-results-summary: true
-        - linux: test-pyargs-xdist
-          python-version: 3.11
-        - linux: test-cov-xdist
-          python-version: 3.12
+        - linux: py311-pyargs-xdist
+        - linux: py312-cov-xdist
           coverage: codecov
           pytest-results-summary: true
-        - macos: test-xdist
-          python-version: 3.12
+        - macos: py312-xdist
           pytest-results-summary: true
-        - windows: test-xdist
-          python-version: 3.12
+        - windows: py312-xdist
           pytest-results-summary: true
-        - linux: test-dev-xdist
-          python-version: 3.12
+        - linux: py312-dev-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,30 @@
 [project]
 name = "tweakwcs"
 description = "A package for correcting alignment errors in WCS objects"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Mihai Cara", email = "help@stsci.edu" },
 ]
 dependencies = [
     "numpy",
-    'astropy>=5.0.4',
-    'gwcs>=0.14.0',
-    'stsci.stimage',
-    'stsci.imagestats',
-    'spherical_geometry>=1.2.20',
-    'packaging>=19.0',
+    "astropy>=5.0.4",
+    "gwcs>=0.14.0",
+    "stsci.stimage",
+    "stsci.imagestats",
+    "spherical_geometry>=1.2.20",
+    "packaging>=19.0",
 ]
 dynamic = [
     "version",
 ]
 classifiers = [
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Topic :: Scientific/Engineering :: Astronomy',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-    'Development Status :: 4 - Beta',
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering :: Astronomy",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Development Status :: 4 - Beta",
 ]
 
 [project.readme]
@@ -49,12 +49,12 @@ test = [
 ]
 docs = [
     "tomli; python_version<'3.11'",
-    'numpydoc',
-    'sphinx',
-    'sphinx-automodapi',
-    'sphinx-rtd-theme',
-    'stsci-rtd-theme',
-    'graphviz',
+    "numpydoc",
+    "sphinx",
+    "sphinx-automodapi",
+    "sphinx-rtd-theme",
+    "stsci-rtd-theme",
+    "graphviz",
 ]
 
 [build-system]
@@ -68,21 +68,25 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-license-files = ["LICENSE.rst"]
+license-files = [
+    "LICENSE.rst",
+]
 
 [tool.setuptools.packages.find]
 namespaces = true
 
 [tool.setuptools.package-data]
 "*" = [
-    'notebooks/*.ipynb',
+    "notebooks/*.ipynb",
 ]
-"tweakwcs" = [
-    'README.rst',
-    'LICENSE.txt',
-    'CHANGELOG.rst',
+tweakwcs = [
+    "README.rst",
+    "LICENSE.txt",
+    "CHANGELOG.rst",
 ]
-"tweakwcs.tests.data" = ["tweakwcs/tests/data/*"]
+"tweakwcs.tests.data" = [
+    "tweakwcs/tests/data/*",
+]
 
 [tool.setuptools_scm]
 write_to = "tweakwcs/_version.py"


### PR DESCRIPTION
resolves [SCSB-145](https://jira.stsci.edu/browse/SCSB-145)

propagate Astropy's deprecation of Python 3.9 to downstream packages


> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: