### PR TITLE
catch RuntimeError and raise custom exception for xyxymatch error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Release Notes
 
 - ``align_wcs`` now will raise a custom exception of type ``NotEnoughCatalogs``
   when there are not enough input catalogs to perform alignment. [#203]
+ 
+- ``XYXYMatch`` now will raise a custom exception of type ``MultiMatchError``
+  when multipe reference sources match a single input source. [#204]
 
 
 0.8.7 (29-March-2024)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Release Notes
 - ``align_wcs`` now will raise a custom exception of type ``NotEnoughCatalogs``
   when there are not enough input catalogs to perform alignment. [#203]
  
-- ``XYXYMatch`` now will raise a custom exception of type ``MultiMatchError``
+- ``XYXYMatch`` now will raise a custom exception of type ``MatchSourceConfusionError``
   when multipe reference sources match a single input source. [#204]
 
 

--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -31,7 +31,7 @@ log.setLevel(logging.DEBUG)
 class MatchSourceConfusionError(RuntimeError):
     """
     Error indicating that multiple sources matched to a single reference
-    source.
+    source. Try different values for ``tolerance`` and ``separation``to fix this error.
     """
 
 

--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -31,7 +31,7 @@ log.setLevel(logging.DEBUG)
 class MatchSourceConfusionError(RuntimeError):
     """
     Error indicating that multiple sources matched to a single reference
-    source. Try different values for ``tolerance`` and ``separation``to fix this error.
+    source. Try different values for ``tolerance`` and ``separation`` to fix this error.
     """
 
 

--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -22,13 +22,13 @@ from . import __version__  # noqa: F401
 
 __author__ = 'Mihai Cara'
 
-__all__ = ['MatchCatalogs', 'XYXYMatch', 'MultiMatchError']
+__all__ = ['MatchCatalogs', 'XYXYMatch', 'MatchSourceConfusionError']
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-class MultiMatchError(RuntimeError):
+class MatchSourceConfusionError(RuntimeError):
     """
     Error indicating that multiple sources matched to a single reference
     source.
@@ -284,7 +284,7 @@ class XYXYMatch(MatchCatalogs):
         except RuntimeError as e:
             msg = e.args[0]
             if msg.startswith("Number of output coordinates exceeded allocation"):
-                raise MultiMatchError(msg)
+                raise MatchSourceConfusionError(msg)
             raise e
 
         return matches['ref_idx'], matches['input_idx']

--- a/tweakwcs/matchutils.py
+++ b/tweakwcs/matchutils.py
@@ -187,6 +187,11 @@ class XYXYMatch(MatchCatalogs):
             A tuple of two 1D `numpy.ndarray` containing indices of matched
             sources in the ``refcat`` and ``imcat`` catalogs accordingly.
 
+        Raises
+        ------
+        MatchSourceConfusionError
+            Multiple sources matched a single reference source. Try different
+            values for ``tolerance`` and ``separation`` to fix this error.
         """
         # Check catalogs:
         if not isinstance(refcat, astropy.table.Table):

--- a/tweakwcs/tests/test_matchutils.py
+++ b/tweakwcs/tests/test_matchutils.py
@@ -18,7 +18,7 @@ from astropy.utils.data import get_pkg_data_filename
 import tweakwcs
 from tweakwcs.matchutils import (_xy_2dhist, _estimate_2dhist_shift,
                                  _find_peak, XYXYMatch, MatchCatalogs,
-                                 MultiMatchError)
+                                 MatchSourceConfusionError)
 from .helper_correctors import DummyWCSCorrector
 
 
@@ -298,7 +298,7 @@ def test_multi_match_error():
     tpmatch = XYXYMatch(tolerance=1.0, separation=0.01)
     refcat = Table([[0.0, 0.1], [0.1, 0.0]], names=('TPx', 'TPy'), meta={'name': None})
     imcat = Table([[0.0], [0.0]], names=('TPx', 'TPy'), meta={'name': None})
-    with pytest.raises(MultiMatchError):
+    with pytest.raises(MatchSourceConfusionError):
         tpmatch(refcat, imcat)
 
 

--- a/tweakwcs/tests/test_matchutils.py
+++ b/tweakwcs/tests/test_matchutils.py
@@ -17,7 +17,8 @@ from astropy.utils.data import get_pkg_data_filename
 
 import tweakwcs
 from tweakwcs.matchutils import (_xy_2dhist, _estimate_2dhist_shift,
-                                 _find_peak, XYXYMatch, MatchCatalogs)
+                                 _find_peak, XYXYMatch, MatchCatalogs,
+                                 MultiMatchError)
 from .helper_correctors import DummyWCSCorrector
 
 
@@ -291,6 +292,14 @@ def test_tpmatch(tp_wcs, use2dhist):
         tp_pscale=tp_pscale,
         tp_units=None if tp_wcs is None else tp_wcs.units
     )
+
+
+def test_multi_match_error():
+    tpmatch = XYXYMatch(tolerance=1.0, separation=0.01)
+    refcat = Table([[0.0, 0.1], [0.1, 0.0]], names=('TPx', 'TPy'), meta={'name': None})
+    imcat = Table([[0.0], [0.0]], names=('TPx', 'TPy'), meta={'name': None})
+    with pytest.raises(MultiMatchError):
+        tpmatch(refcat, imcat)
 
 
 def test_match_catalogs_abc():


### PR DESCRIPTION
This PR catches the `RuntimeError` raised by `xyxymatch` when multiple reference sources match a single source and raises a custom exception.

This change is motivated by the error handling code in jwst and romancal which inspect the error message and can be simplified once the changes in this PR are released.

See the below linked issue for details and why this change is being made in tweakwcs instead of `xyxymatch`

Closes https://github.com/spacetelescope/stsci.stimage/issues/33