### PR TITLE
Use a more robust intersection area computation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,17 +4,24 @@
 Release Notes
 =============
 
-.. 0.8.8 (unreleased)
+.. 0.8.9 (unreleased)
    ==================
 
-0.8.8 (unreleased)
-==================
+0.8.8 (17-July-2024)
+====================
+
+- Use a more robust algorithm for computing intersection polygon area that
+  ignores intersection polygons that raise ``MalformedPolygonError`` in the
+  ``spherical_geometry`` package. This may result in sub-optimal alignment
+  *order* but in practice, it should have minimal effect
+  on the end result. [#281]
 
 - ``align_wcs`` now will raise a custom exception of type ``NotEnoughCatalogs``
   when there are not enough input catalogs to perform alignment. [#203]
- 
-- ``XYXYMatch`` now will raise a custom exception of type ``MatchSourceConfusionError``
-  when multipe reference sources match a single input source. [#204]
+
+- ``XYXYMatch`` now will raise a custom exception of type
+  ``MatchSourceConfusionError`` when multipe reference sources match a single
+  input source. [#204]
 
 
 0.8.7 (29-March-2024)

--- a/tweakwcs/imalign.py
+++ b/tweakwcs/imalign.py
@@ -777,11 +777,21 @@ def overlap_matrix(images):
     """
     nimg = len(images)
     m = np.zeros((nimg, nimg), dtype=np.double)
+    n_malformed = 0
     for i in range(nimg):
         for j in range(i + 1, nimg):
-            area = images[i]._guarded_intersection_area(images[j])
+            area, nf = images[i]._guarded_intersection_area(images[j])
+            n_malformed += nf
             m[j, i] = area
             m[i, j] = area
+
+    if n_malformed:
+        log.warning(
+            "MalformedPolygonError in spherical_geometry. Using "
+            "convex hull instead of multi_union. Alignment order "
+            "may be sub-optimal."
+        )
+
     return m
 
 
@@ -947,7 +957,7 @@ def _max_overlap_pair(images, enforce_user_order):
         # Also, when ref. catalog is static - revert to old tweakreg behavior
         im1 = images.pop(0)  # reference image
         im2 = images.pop(0)
-        overlap_area = im1._guarded_intersection_area(im2)
+        overlap_area = im1._guarded_intersection_area(im2)[0]
         return im1, im2, overlap_area
 
     m = overlap_matrix(images)
@@ -1018,7 +1028,20 @@ def _max_overlap_image(refimage, images, enforce_user_order):
         # revert to old tweakreg behavior
         return images.pop(0), None
 
-    overlap_area = [refimage.intersection_area(im) for im in images]
+    n_malformed = 0
+    overlap_area = []
+    for im in images:
+        area, nf = refimage._guarded_intersection_area(im)
+        overlap_area.append(area)
+        n_malformed += nf
+
+    if n_malformed:
+        log.warning(
+            "MalformedPolygonError in spherical_geometry. Using "
+            "convex hull instead of multi_union. Alignment order "
+            "may be sub-optimal."
+        )
+
     idx = np.argmax(overlap_area)
 
     return images.pop(idx), overlap_area[idx]

--- a/tweakwcs/tests/test_wcsimage.py
+++ b/tweakwcs/tests/test_wcsimage.py
@@ -120,7 +120,7 @@ def test_wcsimcat_intersections(mock_fits_wcs, rect_imcat):
 
 def test_wcsimcat_guarded_intersection_area(mock_fits_wcs, rect_imcat):
     assert np.allclose(
-        rect_imcat._guarded_intersection_area(rect_imcat),
+        rect_imcat._guarded_intersection_area(rect_imcat)[0],
         2.9904967391303217e-12, atol=0.0, rtol=5.0e-4
     )
 
@@ -241,7 +241,7 @@ def test_wcsgroupcat_intersections(mock_fits_wcs, rect_imcat):
 def test_wcsgroupcat_guarded_intersection_area(mock_fits_wcs, rect_imcat):
     g = WCSGroupCatalog(rect_imcat)
     assert np.allclose(
-        g._guarded_intersection_area(g), 2.9904967391303217e-12,
+        g._guarded_intersection_area(g)[0], 2.9904967391303217e-12,
         atol=0.0, rtol=5.0e-4
     )
 
@@ -458,7 +458,9 @@ def test_wcsrefcat_guarded_intersection_area(mock_fits_wcs, rect_imcat):
     ref.calc_tanp_xy(rect_imcat.corrector)
 
     assert np.allclose(
-        ref._guarded_intersection_area(ref), 2.9902125220360176e-10, atol=0.0,
+        ref._guarded_intersection_area(ref)[0],
+        2.9902125220360176e-10,
+        atol=0.0,
         rtol=0.005,
     )
 


### PR DESCRIPTION
Fixes a crash reported in https://jira.stsci.edu/browse/JP-3636 due to `spherical_geometry` raising `MalformedPolygonError` exception when computing area of some intersection polygons. Now, when this error is occurs, it is caught and the intersection area is set to 0. This has potential to result in sub-optimal _order_ in which images will be aligned but in practice should have minimal effect. 