### PR TITLE
Correct exception message when too few objects are matched

### DIFF
--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -1372,8 +1372,8 @@ class WCSGroupCatalog(object):
 
         if nmatches < minobj:
             name = 'Unnamed' if self.name is None else self.name
-            log.warning("Not enough matches (< {:d}) found for image "
-                        "catalog '{:s}'.".format(nmatches, name))
+            log.warning("Not enough matches ({nmatches:d}) found for image "
+                        "catalog '{name:s}'. Min requred: {minobj:d}.")
             for imcat in self:
                 imcat.fit_status = 'FAILED: not enough matches'
             return False


### PR DESCRIPTION
Fixes incorrect message of the exception raised when not enough sources are matched. Reported by a user.