### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ dependencies = [
     "spherical_geometry>=1.2.20",
     "packaging>=21.1",
 ]
+license-files = ["LICENSE.txt"]
 dynamic = [
     "version",
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering :: Astronomy",
@@ -30,10 +30,6 @@ classifiers = [
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"
-
-[project.license]
-file = "LICENSE.txt"
-content-type = "text/plain"
 
 [project.urls]
 Homepage = "https://github.com/spacetelescope/tweakwcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-license-files = [
-    "LICENSE.rst",
-]
 
 [tool.setuptools.packages.find]
 namespaces = true


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))