### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Documentation = "http://spacetelescope.github.io/tweakwcs/"
 
 [project.optional-dependencies]
 test = [
-    "pytest",
+    "pytest>=9.0",
     "pytest-cov",
     "scipy",
 ]
@@ -92,15 +92,15 @@ all_files = "1"
 upload-dir = "docs/_build/html"
 show-response = 1
 
-[tool.pytest.ini_options]
-minversion = "4.6"
+[tool.pytest]
+minversion = "9.0"
 norecursedirs = [
     "build",
     "docs/_build",
     ".tox",
 ]
 doctest_plus = "enabled"
-addopts = "--ignore=build"
+addopts = ["--ignore=build"]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`