### PR TITLE
Fix an unfortunate unit test

### DIFF
--- a/tweakwcs/tests/test_wcsimage.py
+++ b/tweakwcs/tests/test_wcsimage.py
@@ -82,7 +82,8 @@ def test_wcsimcat_set_none_catalog(mock_fits_wcs, rect_imcat):
 
 def test_wcsimcat_wcs_transforms_roundtrip(mock_fits_wcs):
     x = np.arange(5)
-    y = np.random.permutation(5)
+    y = np.array([2, 1, 4, 0, 3], dtype=float)
+
     imcat = Table([x, y], names=('x', 'y'))
     corr = FITSWCSCorrector(mock_fits_wcs)
     w = WCSImageCatalog(imcat, corr)


### PR DESCRIPTION
Fixes #245 

It looks like one of the tests can create a set of points all along a straight line, resulting in a convex hull with too few points to define a polygon. This PR hardcodes a set of test points that are not collinear.
