### PR TITLE
JP-4372: Fix edge cases in bounding box computations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
       envs: |
-        - macos: py311-numpy121-xdist
-        - linux: py311-numpy125-xdist
         - linux: py311-xdist
           pytest-results-summary: true
         - macos: py311-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
       envs: |
+        - macos: py311-numpy121-xdist
+        - linux: py311-numpy125-xdist
         - linux: py311-xdist
           pytest-results-summary: true
         - macos: py311-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
       envs: |
-        - macos: py310-numpy121-xdist
-        - linux: py310-numpy125-xdist
+        - macos: py311-numpy121-xdist
+        - linux: py311-numpy125-xdist
         - linux: py311-xdist
           pytest-results-summary: true
         - macos: py311-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
       envs: |
-        - macos: py311-numpy121-xdist
         - linux: py311-numpy125-xdist
         - linux: py311-xdist
           pytest-results-summary: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Release Notes
 0.9.1 (unreleased)
 ==================
 
-- Improved handling of edge cases in bounding poligon calculations for
+- Improved handling of edge cases in bounding polygon calculations for
   catalogs in the ``WCSImage`` class. [#254]
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Release Notes
 =============
 
 
+0.9.1 (unreleased)
+==================
+
+- Improved handling of edge cases in bounding poligon calculations for
+  catalogs in the ``WCSImage`` class. [#254]
+
+
 0.9.0 (14-May-2026)
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ Release Notes
 =============
 
 
-0.9.1 (unreleased)
-==================
+0.9.1 (30-June-2026)
+====================
 
 - Improved handling of edge cases in bounding polygon calculations for
   catalogs in the ``WCSImage`` class. [#254]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Mihai Cara" },
 ]
 dependencies = [
-    "numpy",
+    "numpy>=1.25.0",
     "astropy>=5.0.4",
     "gwcs>=0.14.0",
     "stsci.stimage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tweakwcs"
 description = "A package for correcting alignment errors in WCS objects"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Mihai Cara" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "astropy>=5.0.4",
     "gwcs>=0.14.0",
     "stsci.stimage",
-    "spherical_geometry>=1.2.20",
+    "spherical_geometry>=1.4.0",
     "packaging>=21.1",
 ]
 license-files = ["LICENSE.txt"]

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -501,9 +501,8 @@ class WCSImageCatalog:
 
         elif len(x) > 2:
             x, y = convex_hull(x, y, wcs=None, min_separation=0.0001)
-            # else, for len(x) in [1, 2], use entire image footprint.
-            # TODO: a more robust algorithm should be implemented to deal with
-            #       len(x) in [1, 2] cases.
+            # convex hull returns a closed polygon, so we do not need to close
+            # it again.
 
             if len(x) > 3:
                 # convert x, y vertex coordinates to RA & DEC:
@@ -514,6 +513,7 @@ class WCSImageCatalog:
                 p = SphericalPolygon.from_radec(ra, dec)
 
                 if not p.degenerate:
+                    # we have a valid polygon, so we can use it:
                     self._polygon = p
                     self._bb_radec = (ra, dec)
                     self._poly_area = np.fabs(p.area())
@@ -529,16 +529,54 @@ class WCSImageCatalog:
             dx = x[1] - x[0]
             dy = y[1] - y[0]
             d = np.sqrt(dx * dx + dy * dy)
-            dx /= d
-            dy /= d
-            du = -dy
-            dv = dx
-            # build a rectangle by shifting the line segment by 0.5 in the
-            # direction perpendicular to the line:
-            x = np.array([x[0] + 0.5 * du, x[0] - 0.5 * du, x[1] - 0.5 * du, x[1] + 0.5 * du, x[0] + 0.5 * du])
-            y = np.array([y[0] + 0.5 * dv, y[0] - 0.5 * dv, y[1] - 0.5 * dv, y[1] + 0.5 * dv, y[0] + 0.5 * dv])
+            if d < 0.0001:
+                # two points are the same, so we create a small box centered
+                # on the point:
+                x = np.array(
+                    [
+                        x[0] - 0.5,
+                        x[0] + 0.5,
+                        x[0] + 0.5,
+                        x[0] - 0.5,
+                        x[0] - 0.5
+                    ]
+                )
+                y = np.array(
+                    [
+                        y[0] - 0.5,
+                        y[0] - 0.5,
+                        y[0] + 0.5,
+                        y[0] + 0.5,
+                        y[0] - 0.5
+                    ]
+                )
+            else:
+                dx /= d
+                dy /= d
+                du = -dy
+                dv = dx
+                # build a rectangle by shifting the line segment by 0.5 in the
+                # direction perpendicular to the line:
+                x = np.array(
+                    [
+                        x[0] + 0.5 * du,
+                        x[0] - 0.5 * du,
+                        x[1] - 0.5 * du,
+                        x[1] + 0.5 * du,
+                        x[0] + 0.5 * du
+                    ]
+                )
+                y = np.array(
+                    [
+                        y[0] + 0.5 * dv,
+                        y[0] - 0.5 * dv,
+                        y[1] - 0.5 * dv,
+                        y[1] + 0.5 * dv,
+                        y[0] + 0.5 * dv
+                    ]
+                )
 
-        elif len(x) > 3:
+        elif len(x) >= 3:
             # find minimal area rectangle that contains all points:
             min_area = np.inf
             for p1, p2 in zip(zip(x, y), zip(x[1:] + [x[0]], y[1:] + [y[0]])):

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -533,14 +533,10 @@ class WCSImageCatalog:
             dy /= d
             du = -dy
             dv = dx
-            p1x = x[0] - 0.5 * dx
-            p1y = y[0] - 0.5 * dy
-            p2x = x[1] + 0.5 * dx
-            p2y = y[1] + 0.5 * dy
             # build a rectangle by shifting the line segment by 0.5 in the
             # direction perpendicular to the line:
-            x = np.array([p1x + 0.5 * du, p1x - 0.5 * du, p2x - 0.5 * du, p2x + 0.5 * du, p1x + 0.5 * du])
-            y = np.array([p1y + 0.5 * dv, p1y - 0.5 * dv, p2y - 0.5 * dv, p2y + 0.5 * dv, p1y + 0.5 * dv])
+            x = np.array([x[0] + 0.5 * du, x[0] - 0.5 * du, x[1] - 0.5 * du, x[1] + 0.5 * du, x[0] + 0.5 * du])
+            y = np.array([y[0] + 0.5 * dv, y[0] - 0.5 * dv, y[1] - 0.5 * dv, y[1] + 0.5 * dv, y[0] + 0.5 * dv])
 
         elif len(x) > 3:
             # find minimal area rectangle that contains all points:

--- a/tweakwcs/wcsimage.py
+++ b/tweakwcs/wcsimage.py
@@ -500,14 +500,103 @@ class WCSImageCatalog:
             )
 
         elif len(x) > 2:
-            ra, dec = convex_hull(x, y, wcs=self.det_to_world, min_separation=1e-11)
+            x, y = convex_hull(x, y, wcs=None, min_separation=0.0001)
             # else, for len(x) in [1, 2], use entire image footprint.
             # TODO: a more robust algorithm should be implemented to deal with
             #       len(x) in [1, 2] cases.
 
+            if len(x) > 3:
+                # convert x, y vertex coordinates to RA & DEC:
+                ra, dec = self.det_to_world(x, y)
+                ra[-1] = ra[0]
+                dec[-1] = dec[0]
+
+                p = SphericalPolygon.from_radec(ra, dec)
+
+                if not p.degenerate:
+                    self._polygon = p
+                    self._bb_radec = (ra, dec)
+                    self._poly_area = np.fabs(p.area())
+                    return
+
+        if len(x) == 1:
+            # one point: create a small box centered on the point:
+            x = np.array([x[0] - 0.5, x[0] + 0.5, x[0] + 0.5, x[0] - 0.5, x[0] - 0.5])
+            y = np.array([y[0] - 0.5, y[0] - 0.5, y[0] + 0.5, y[0] + 0.5, y[0] - 0.5])
+
+        elif len(x) == 2:
+            # two points: create a small box that contains both points:
+            dx = x[1] - x[0]
+            dy = y[1] - y[0]
+            d = np.sqrt(dx * dx + dy * dy)
+            dx /= d
+            dy /= d
+            du = -dy
+            dv = dx
+            p1x = x[0] - 0.5 * dx
+            p1y = y[0] - 0.5 * dy
+            p2x = x[1] + 0.5 * dx
+            p2y = y[1] + 0.5 * dy
+            # build a rectangle by shifting the line segment by 0.5 in the
+            # direction perpendicular to the line:
+            x = np.array([p1x + 0.5 * du, p1x - 0.5 * du, p2x - 0.5 * du, p2x + 0.5 * du, p1x + 0.5 * du])
+            y = np.array([p1y + 0.5 * dv, p1y - 0.5 * dv, p2y - 0.5 * dv, p2y + 0.5 * dv, p1y + 0.5 * dv])
+
+        elif len(x) > 3:
+            # find minimal area rectangle that contains all points:
+            min_area = np.inf
+            for p1, p2 in zip(zip(x, y), zip(x[1:] + [x[0]], y[1:] + [y[0]])):
+                dx = p2[0] - p1[0]
+                dy = p2[1] - p1[1]
+                d = np.sqrt(dx * dx + dy * dy)
+                dx /= d
+                dy /= d
+                du = -dy
+                dv = dx
+                min_u = np.inf
+                max_u = -np.inf
+                min_v = np.inf
+                max_v = -np.inf
+                for px, py in zip(x, y):
+                    u = (px - p1[0]) * dx + (py - p1[1]) * dy
+                    v = (px - p1[0]) * du + (py - p1[1]) * dv
+                    min_u = min(min_u, u) - 0.5
+                    max_u = max(max_u, u) + 0.5
+                    min_v = min(min_v, v) - 0.5
+                    max_v = max(max_v, v) + 0.5
+                area = (max_u - min_u) * (max_v - min_v)
+                if area < min_area:
+                    min_area = area
+                    x = np.array(
+                        [
+                            p1[0] + min_u * dx + min_v * du,
+                            p1[0] + min_u * dx - max_v * du,
+                            p1[0] + max_u * dx - max_v * du,
+                            p1[0] + max_u * dx + min_v * du,
+                            p1[0] + min_u * dx + min_v * du,
+                        ]
+                    )
+                    y = np.array(
+                        [
+                            p1[1] + min_u * dy + min_v * dv,
+                            p1[1] + min_u * dy - max_v * dv,
+                            p1[1] + max_u * dy - max_v * dv,
+                            p1[1] + max_u * dy + min_v * dv,
+                            p1[1] + min_u * dy + min_v * dv,
+                        ]
+                    )
+
+            # convert x, y vertex coordinates to RA & DEC:
+            ra, dec = self.det_to_world(x, y)
+            ra[-1] = ra[0]
+            dec[-1] = dec[0]
+
+            p = SphericalPolygon.from_radec(ra, dec)
+
+            self._polygon = p
             self._bb_radec = (ra, dec)
-            self._polygon = SphericalPolygon.from_radec(ra, dec)
-            self._poly_area = np.fabs(self._polygon.area())
+            self._poly_area = np.fabs(p.area())
+
 
     def calc_bounding_polygon(self):
         """


### PR DESCRIPTION
Fixes a crash in the JWST pipeline which happens when one of the images has three sources detected and they lie on almost a straight line. The convex hull of these points is a triangle with minimal height resulting in the spherical polygon being considered degenerate since all vertices lie on a great circle.

This PR replaces convex hull with a bounding rectangle of height or with of no less than 1 pixel only when the spherical polygon created with the convex hull is degenerate.

Closes [JP-4372](https://jira.stsci.edu/browse/JP-4372)

Regression tests:
- JWST: https://github.com/spacetelescope/RegressionTests/actions/runs/27257813514
- JWST (`CRDS_CONTEXT=jwst_1555.pmap`): https://github.com/spacetelescope/RegressionTests/actions/runs/27310278928
- Roman: https://github.com/spacetelescope/RegressionTests/actions/runs/27257905170